### PR TITLE
Adding scope to signature

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-#npx pretty-quick --staged && npm run lint && npm test && git add -A
+npx pretty-quick --staged && npm run lint && npm test && git add -A

--- a/contracts/manager/Actor.sol
+++ b/contracts/manager/Actor.sol
@@ -12,6 +12,10 @@ contract Actor is IActor {
   error ActorAlreadyAdded();
   error TooManyActors();
 
+  bytes32 public constant PROTECTOR = keccak256(abi.encodePacked("PROTECTOR"));
+  bytes32 public constant SENTINEL = keccak256(abi.encodePacked("SENTINEL"));
+  bytes32 public constant SAFE_RECIPIENT = keccak256(abi.encodePacked("SAFE_RECIPIENT"));
+
   mapping(bytes32 => Actor[]) private _actors;
   Actor private _emptyActor = Actor(address(0), Status.UNSET, Level.NONE);
 
@@ -61,7 +65,7 @@ contract Actor is IActor {
   }
 
   function _listActiveActors(bytes32 role) internal view returns (address[] memory) {
-    uint256 count = role == _role("PROTECTOR") ? _countActiveActorsByRole(role) : _actorLength(role);
+    uint256 count = role == PROTECTOR ? _countActiveActorsByRole(role) : _actorLength(role);
     address[] memory actors = new address[](count);
     uint256 j = 0;
     for (uint256 i = 0; i < _actors[role].length; i++) {
@@ -113,10 +117,6 @@ contract Actor is IActor {
     Status status = _actorStatus(actor_, role);
     if (status != Status.UNSET) revert ActorAlreadyAdded();
     _actors[role].push(Actor(actor_, status_, level));
-  }
-
-  function _role(string memory role_) internal pure returns (bytes32) {
-    return keccak256(bytes(role_));
   }
 
   /**

--- a/contracts/protected/ProtectedNFT.sol
+++ b/contracts/protected/ProtectedNFT.sol
@@ -100,6 +100,7 @@ abstract contract ProtectedNFT is IProtected, Versioned, IERC6454, ERC721, Ownab
     if (usedSignatures[keccak256(signature)]) revert SignatureAlreadyUsed();
     usedSignatures[keccak256(signature)] = true;
     address signer = managers[tokenId].signatureValidator().recoverSigner(
+      managers[tokenId].signatureValidator().getSupportedScope("PROTECTED_TRANSFER"),
       _msgSender(),
       to,
       tokenId,

--- a/test/SignatureValidator.test.js
+++ b/test/SignatureValidator.test.js
@@ -30,12 +30,15 @@ describe("SignatureValidator", function () {
   });
 
   it("should recover the signer of a recoverSigner", async function () {
+    let scope = await validator.getSupportedScope("SENTINEL");
+
     const message = {
+      scope: scope.toString(),
       owner: tokenOwner.address,
       actor: protector.address,
       tokenId: 1,
-      extraValue: 19928273,
-      timestamp: (await getTimestamp()) - 100,
+      extraValue: 3,
+      timestamp: 1700453731,
       validFor: 3600,
     };
 
@@ -45,6 +48,7 @@ describe("SignatureValidator", function () {
       privateKeyByWallet[protector.address],
       "Auth",
       [
+        {name: "scope", type: "uint256"},
         {name: "owner", type: "address"},
         {name: "actor", type: "address"},
         {name: "tokenId", type: "uint256"},
@@ -57,6 +61,7 @@ describe("SignatureValidator", function () {
 
     expect(
       await validator.recoverSigner(
+        message.scope,
         message.owner,
         message.actor,
         message.tokenId,

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -166,8 +166,11 @@ const Helpers = {
     return types;
   },
 
-  async signRequest(owner, actor, tokenId, extraValue, timestamp, validFor, chainId, signer, validator) {
+  async signRequest(scope, owner, actor, tokenId, extraValue, timestamp, validFor, chainId, signer, validator) {
+    scope = await validator.getSupportedScope(scope);
+
     const message = {
+      scope: scope.toString(),
       owner,
       actor,
       tokenId: tokenId.toString(),
@@ -181,6 +184,7 @@ const Helpers = {
       Helpers.privateKeyByWallet[signer],
       "Auth",
       [
+        {name: "scope", type: "uint256"},
         {name: "owner", type: "address"},
         {name: "actor", type: "address"},
         {name: "tokenId", type: "uint256"},


### PR DESCRIPTION
Tests pass for setting protectors, sentinels and safe recipients.
I added a scope in the signature because if not someone could ask for a signature to set a type of actor and use it for a different one.
I tried to put in the signature the string, but it looks like that is not supported, and so I added a function to get the supported role, passing the string. It is not readable during the signature, but if we make clear that PROTECTOR is 1, etc., it should be ok.
