### PR TITLE
Allow only EOA wallets to be protectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Cruna Vault is more than just an NFT; it's a comprehensive solution for securing
 
 ## Development
 
-Cruna is in alpha stage, and to use it you must specify the version you want to install. Right now, the only available version is `1.0.0-alpha.0`. Install it with
+Cruna is in alpha stage, and to use it you must specify the version you want to install. Right now, the only available version is `1.0.0-alpha.1`. Install it with
 
 ```sh
-npm install @cruna/protocol@1.0.0-alpha.0 @openzeppelin/contracts erc6551
+npm install @cruna/protocol@1.0.0-alpha.1 @openzeppelin/contracts erc6551
 ```
 or similar commands using Yarn or Pnpm, and use in your Solidity smart contracts, for example, as
 
@@ -133,7 +133,7 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 
 ## History
 
-**1.0.0-alpha.0**
+**1.0.0-alpha.1**
 
 - First version of the new protocol. The first one, published as @cruna/cruna-protocol, has been deprecated.
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 ## Test coverage
 
 ```
-  22 passing (8s)
+  22 passing (6s)
 
 --------------------------------|----------|----------|----------|----------|----------------|
 File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
@@ -154,11 +154,11 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
   IProtected.sol                |      100 |      100 |      100 |      100 |                |
- contracts/manager/             |    98.95 |    67.11 |      100 |    99.12 |                |
+ contracts/manager/             |    98.96 |    66.67 |      100 |    99.13 |                |
   Actor.sol                     |      100 |    66.67 |      100 |      100 |                |
   FlexiGuardian.sol             |      100 |       50 |      100 |    83.33 |             19 |
   IManager.sol                  |      100 |      100 |      100 |      100 |                |
-  Manager.sol                   |      100 |       66 |      100 |      100 |                |
+  Manager.sol                   |      100 |    65.38 |      100 |      100 |                |
   ManagerBase.sol               |    93.33 |       80 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
@@ -173,7 +173,7 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   SignatureValidator.sol        |      100 |      100 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    99.52 |    61.11 |     98.8 |    98.13 |                |
+All files                       |    99.52 |    61.01 |     98.8 |    98.13 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/contracts/manager/Manager.sol
+++ b/contracts/manager/Manager.sol
@@ -7,6 +7,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {IERC6551Registry} from "erc6551/interfaces/IERC6551Registry.sol";
 import {SignatureValidator} from "../utils/SignatureValidator.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 import {Actor} from "./Actor.sol";
 import {IManager} from "./IManager.sol";
@@ -27,6 +28,7 @@ interface IVault {
 contract Manager is IManager, Actor, ManagerBase {
   using ECDSA for bytes32;
   using Strings for uint256;
+  using Address for address;
 
   error TimestampZero();
   error Forbidden();
@@ -41,6 +43,7 @@ contract Manager is IManager, Actor, ManagerBase {
   error PluginAlreadyPlugged();
   error RoleNotFound();
   error NotAProxy();
+  error ContractsCannotBeProtectors();
 
   bool public constant IS_MANAGER = true;
   bool public constant IS_NOT_MANAGER = false;
@@ -128,6 +131,7 @@ contract Manager is IManager, Actor, ManagerBase {
     uint256 validFor,
     bytes calldata signature
   ) external virtual override onlyTokenOwner {
+    if (protector_.isContract()) revert ContractsCannotBeProtectors();
     _setSignedActor("PROTECTOR", protector_, PROTECTOR, status, timestamp, validFor, signature, IS_MANAGER);
     emit ProtectorUpdated(_msgSender(), protector_, status);
     if (status) {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/protocol",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "The Cruna protocol",
   "publishConfig": {
     "access": "public"

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -152,6 +152,11 @@
       },
       {
         "inputs": [],
+        "name": "ContractsCannotBeProtectors",
+        "type": "error"
+      },
+      {
+        "inputs": [],
         "name": "Forbidden",
         "type": "error"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/protocol",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "description": "The Cruna protocol",
   "publishConfig": {
     "access": "public"

--- a/test/nickSFactory.test.js
+++ b/test/nickSFactory.test.js
@@ -33,7 +33,7 @@ describe("Nick's factory", function () {
 
     const managerAddress = await deployContractViaNickSFactory(deployer, "Manager", "contracts/manager");
     manager = await ethers.getContractAt("Manager", managerAddress);
-    expect(manager.address).equal("0x8Fde09a3EeCF7F9f3506EC5766911F535999f607");
+    expect(manager.address).equal("0x7B42F0368AB633f500AF4126b8A3e7a439a055D0");
     expect(await manager.version()).equal(1);
 
     const account = await erc6551Registry.account(otto.address, keccak256("otto"), chainId.toString(), fred.address, 1);
@@ -64,7 +64,7 @@ describe("Nick's factory", function () {
       ["address", "address", "address", "address"],
       [erc6551RegistryAddress, guardianAddress, signatureValidatorAddress, managerAddress],
     );
-    expect(vaultAddress).equal("0xda12CEC9f349d67c38f16856536D9113c4E4eA48");
+    expect(vaultAddress).equal("0x79712d461A9D404B6e367990779B40Ed41c1A10f");
   });
 
   it("should mint a vault and deploy the relative manager", async function () {


### PR DESCRIPTION
Since protectors must validate transactions signing a typed message V4, we can not allow contracts to become protectors, because they would not be able to sign the validation. For this reason, in this PR, we check if the protectors is a contract and if yes we revert.

To allow contracts to be protectors, we may reintroduce in a future version the two-transaction approach, where a first transaction by the protector initiates a process, and the owner completes it. However this will add a lot of code and lose the ability to manage general transactions.


