### PR TITLE
Add unplug replug

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 
 ## History
 
+**1.0.0-alpha.3**
+
+- Add function to disable and re-enable plugins
+
 **1.0.0-alpha.2**
 
 - Improve the InheritancePlugin to allow the owner explicitly nominate a beneficiary, in addition to the sentinels
@@ -148,7 +152,7 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 ## Test coverage
 
 ```
-  24 passing (12s)
+  26 passing (11s)
 
 --------------------------------|----------|----------|----------|----------|----------------|
 File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
@@ -162,17 +166,17 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
   IProtected.sol                |      100 |      100 |      100 |      100 |                |
- contracts/manager/             |       99 |       70 |      100 |    98.21 |                |
+ contracts/manager/             |    99.14 |    69.32 |      100 |    98.46 |                |
   Actor.sol                     |      100 |       70 |      100 |      100 |                |
   FlexiGuardian.sol             |      100 |       50 |      100 |    83.33 |             19 |
   IManager.sol                  |      100 |      100 |      100 |      100 |                |
-  Manager.sol                   |      100 |    69.57 |      100 |    98.44 |            252 |
+  Manager.sol                   |      100 |    68.75 |      100 |    98.78 |            289 |
   ManagerBase.sol               |    94.74 |       80 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
- contracts/plugins/inheritance/ |    97.92 |    70.69 |    93.75 |     97.1 |                |
+ contracts/plugins/inheritance/ |    98.04 |       70 |    94.44 |    97.22 |                |
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
-  InheritancePlugin.sol         |    97.92 |    70.69 |    93.33 |     97.1 |         53,144 |
+  InheritancePlugin.sol         |    98.04 |       70 |    94.12 |    97.22 |         53,144 |
   InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
  contracts/protected/           |      100 |       56 |      100 |    97.67 |                |
   ProtectedNFT.sol              |      100 |       56 |      100 |    97.67 |             85 |
@@ -181,7 +185,7 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   SignatureValidator.sol        |      100 |      100 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    98.28 |     62.2 |    95.83 |    96.93 |                |
+All files                       |    98.41 |    62.41 |    96.04 |    97.13 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 ## Test coverage
 
 ```
-  28 passing (12s)
+  28 passing (10s)
 
 --------------------------------|----------|----------|----------|----------|----------------|
 File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
@@ -166,11 +166,11 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
   IProtected.sol                |      100 |      100 |      100 |      100 |                |
- contracts/manager/             |    99.14 |    69.32 |      100 |    98.46 |                |
+ contracts/manager/             |    99.15 |    68.89 |      100 |    97.73 |                |
   Actor.sol                     |      100 |       70 |      100 |      100 |                |
   FlexiGuardian.sol             |      100 |       50 |      100 |    83.33 |             19 |
   IManager.sol                  |      100 |      100 |      100 |      100 |                |
-  Manager.sol                   |      100 |    68.75 |      100 |    98.78 |            289 |
+  Manager.sol                   |      100 |    68.18 |      100 |    97.62 |        286,294 |
   ManagerBase.sol               |    94.74 |       80 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
@@ -185,7 +185,7 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   SignatureValidator.sol        |      100 |      100 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |     99.6 |    63.91 |      100 |    98.09 |                |
+All files                       |     99.6 |    63.81 |      100 |    97.78 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 ## Test coverage
 
 ```
-  26 passing (11s)
+  28 passing (12s)
 
 --------------------------------|----------|----------|----------|----------|----------------|
 File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 --------------------------------|----------|----------|----------|----------|----------------|
  contracts/                     |      100 |       40 |      100 |      100 |                |
   CrunaFlexiVault.sol           |      100 |       40 |      100 |      100 |                |
- contracts/factory/             |    95.56 |    53.45 |    78.57 |    93.22 |                |
+ contracts/factory/             |      100 |    60.34 |      100 |    96.61 |                |
   IVaultFactory.sol             |      100 |      100 |      100 |      100 |                |
-  VaultFactory.sol              |    95.56 |    53.45 |    78.57 |    93.22 |   46,50,65,131 |
+  VaultFactory.sol              |      100 |    60.34 |      100 |    96.61 |         66,132 |
  contracts/interfaces/          |      100 |      100 |      100 |      100 |                |
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
@@ -174,9 +174,9 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   ManagerBase.sol               |    94.74 |       80 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
- contracts/plugins/inheritance/ |    98.04 |       70 |    94.44 |    97.22 |                |
+ contracts/plugins/inheritance/ |      100 |       70 |      100 |    98.61 |                |
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
-  InheritancePlugin.sol         |    98.04 |       70 |    94.12 |    97.22 |         53,144 |
+  InheritancePlugin.sol         |      100 |       70 |      100 |    98.61 |            144 |
   InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
  contracts/protected/           |      100 |       56 |      100 |    97.67 |                |
   ProtectedNFT.sol              |      100 |       56 |      100 |    97.67 |             85 |
@@ -185,7 +185,7 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   SignatureValidator.sol        |      100 |      100 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    98.41 |    62.41 |    96.04 |    97.13 |                |
+All files                       |     99.6 |    63.91 |      100 |    98.09 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/contracts/manager/IManager.sol
+++ b/contracts/manager/IManager.sol
@@ -13,9 +13,13 @@ interface IManager {
   // @dev Emitted when the level of an allowed recipient is updated
   event SafeRecipientUpdated(address indexed owner, address indexed recipient, bool status);
 
-  event PluginPlugged(string name, address plugin);
+  event PluginStatusChange(string name, address plugin, bool status);
 
   function plug(string memory name, address implementation) external;
+
+  function disablePlugin(string memory name, bool resetPlugin) external;
+
+  function reEnablePlugin(string memory name, bool resetPlugin) external;
 
   // simulate ERC-721
 

--- a/contracts/manager/Manager.sol
+++ b/contracts/manager/Manager.sol
@@ -282,7 +282,7 @@ contract Manager is IManager, Actor, ManagerBase {
     for (uint256 i = 0; i < pluginRoles.length; i++) {
       if (address(plugins[pluginNamesByRole[pluginRoles[i]]]) == _msgSender()) {
         if (!plugins[pluginNamesByRole[pluginRoles[i]]].requiresToManageTransfer()) {
-          // The plugin declares it self as not requiring the ability to manage transfers, but in reality it is trying to do so
+          // The plugin declares itself as not requiring the ability to manage transfers, but in reality it is trying to do so
           revert InconsistentPolicy();
         }
         if (disabledPlugins[pluginNamesByRole[pluginRoles[i]]]) revert DisabledPlugin();

--- a/contracts/manager/ManagerBase.sol
+++ b/contracts/manager/ManagerBase.sol
@@ -83,6 +83,10 @@ abstract contract ManagerBase is Context, Versioned {
     return tokenId_;
   }
 
+  // @dev Upgrade the implementation of the manager/plugin
+  //   Notice that the owner can upgrade active or disable plugins
+  //   so that, if a plugin is compromised, the user can disable it,
+  //   wait for a new trusted implementation and upgrade it.
   function upgrade(address implementation_) external virtual {
     if (owner() != _msgSender()) revert NotTheTokenOwner();
     if (!guardian().isTrustedImplementation(nameHash(), implementation_)) revert InvalidImplementation();

--- a/contracts/manager/ManagerBase.sol
+++ b/contracts/manager/ManagerBase.sol
@@ -22,6 +22,10 @@ interface IVault {
   function validator() external view returns (SignatureValidator);
 }
 
+/**
+  @title ManagerBase
+  @dev Base contract for managers and plugins
+*/
 abstract contract ManagerBase is Context, Versioned {
   error NotTheTokenOwner();
   error InvalidImplementation();

--- a/contracts/mocks/VaultFactoryV2Mock.sol
+++ b/contracts/mocks/VaultFactoryV2Mock.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {VaultFactory} from "../factory/VaultFactory.sol";
+
+contract VaultFactoryV2Mock is VaultFactory {
+  function version() public pure virtual override returns (uint256) {
+    return 2;
+  }
+}

--- a/contracts/mocks/plugin-example/simple/SomeSimplePlugin.sol
+++ b/contracts/mocks/plugin-example/simple/SomeSimplePlugin.sol
@@ -53,4 +53,13 @@ contract SomeSimplePlugin is IPlugin, ManagerBase {
   function upgrade(address) external pure override {
     revert NotUpgradeable();
   }
+
+  function reset() external override {
+    if (_msgSender() != address(manager)) revert Forbidden();
+    _reset();
+  }
+
+  function _reset() internal {
+    // reset to initial state
+  }
 }

--- a/contracts/mocks/plugin-example/upgradeable/SomePlugin.sol
+++ b/contracts/mocks/plugin-example/upgradeable/SomePlugin.sol
@@ -40,6 +40,15 @@ contract SomePlugin is IPlugin, ManagerBase {
     // some logic
   }
 
+  function reset() external override {
+    if (_msgSender() != address(manager)) revert Forbidden();
+    _reset();
+  }
+
+  function _reset() internal {
+    // reset to initial state
+  }
+
   // @dev This empty reserved space is put in place to allow future versions to add new
   // variables without shifting down storage in the inheritance chain.
   // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps

--- a/contracts/plugins/IPlugin.sol
+++ b/contracts/plugins/IPlugin.sol
@@ -10,4 +10,7 @@ interface IPlugin {
   // function called in the dashboard to know if the plugin is asking the
   // right to make a managed transfer of the vault
   function requiresToManageTransfer() external pure returns (bool);
+
+  // Reset the plugin to the factory settings
+  function reset() external;
 }

--- a/contracts/plugins/IPlugin.sol
+++ b/contracts/plugins/IPlugin.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.9;
 
-// ERC165 interfaceId 0x6b61a747
+/**
+ @title IPlugin
+ @dev Interface for plugins
+   Technically, plugins are secondary managers, pluggable in
+   the primary manage, which is Manager.sol
+*/
 interface IPlugin {
   function init() external;
 

--- a/contracts/plugins/inheritance/InheritancePlugin.sol
+++ b/contracts/plugins/inheritance/InheritancePlugin.sol
@@ -204,9 +204,18 @@ contract InheritancePlugin is IPlugin, IInheritancePlugin, ManagerBase {
       // so the sentinels can propose a new beneficiary
       if (_isGracePeriodExpiredAfterStart()) revert Expired();
     }
-    delete _inheritanceConf;
+    _reset();
     emit InheritedBy(_msgSender());
     manager.managedTransfer(tokenId(), _msgSender());
+  }
+
+  function reset() external override {
+    if (_msgSender() != address(manager)) revert Forbidden();
+    _reset();
+  }
+
+  function _reset() internal {
+    delete _inheritanceConf;
   }
 
   // @dev This empty reserved space is put in place to allow future versions to add new

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -167,6 +167,11 @@
       },
       {
         "inputs": [],
+        "name": "InconsistentPolicy",
+        "type": "error"
+      },
+      {
+        "inputs": [],
         "name": "InvalidImplementation",
         "type": "error"
       },

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -3551,6 +3551,19 @@
         "type": "function"
       },
       {
+        "inputs": [],
+        "name": "version",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+      },
+      {
         "inputs": [
           {
             "internalType": "address",

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -157,6 +157,11 @@
       },
       {
         "inputs": [],
+        "name": "DisabledPlugin",
+        "type": "error"
+      },
+      {
+        "inputs": [],
         "name": "Forbidden",
         "type": "error"
       },
@@ -193,6 +198,11 @@
       {
         "inputs": [],
         "name": "PluginAlreadyPlugged",
+        "type": "error"
+      },
+      {
+        "inputs": [],
+        "name": "PluginNotFound",
         "type": "error"
       },
       {
@@ -249,9 +259,15 @@
             "internalType": "address",
             "name": "plugin",
             "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "bool",
+            "name": "status",
+            "type": "bool"
           }
         ],
-        "name": "PluginPlugged",
+        "name": "PluginStatusChange",
         "type": "event"
       },
       {
@@ -394,6 +410,43 @@
             "internalType": "uint256",
             "name": "",
             "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "bool",
+            "name": "resetPlugin",
+            "type": "bool"
+          }
+        ],
+        "name": "disablePlugin",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "bytes32",
+            "name": "",
+            "type": "bytes32"
+          }
+        ],
+        "name": "disabledPlugins",
+        "outputs": [
+          {
+            "internalType": "bool",
+            "name": "",
+            "type": "bool"
           }
         ],
         "stateMutability": "view",
@@ -655,7 +708,7 @@
             "type": "bytes32"
           }
         ],
-        "name": "pluginByRole",
+        "name": "pluginNamesByRole",
         "outputs": [
           {
             "internalType": "bytes32",
@@ -702,6 +755,24 @@
           }
         ],
         "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "internalType": "bool",
+            "name": "resetPlugin",
+            "type": "bool"
+          }
+        ],
+        "name": "reEnablePlugin",
+        "outputs": [],
+        "stateMutability": "nonpayable",
         "type": "function"
       },
       {
@@ -1502,6 +1573,13 @@
           }
         ],
         "stateMutability": "pure",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "reset",
+        "outputs": [],
+        "stateMutability": "nonpayable",
         "type": "function"
       },
       {

--- a/test/InheritanceManager.Sentinels.test.js
+++ b/test/InheritanceManager.Sentinels.test.js
@@ -90,6 +90,7 @@ describe("Sentinel and Inheritance", function () {
     const manager = await ethers.getContractAt("Manager", managerAddress);
     const inheritancePluginAddress = await manager.plugins(keccak256("InheritancePlugin"));
     const inheritancePlugin = await ethers.getContractAt("InheritancePlugin", inheritancePluginAddress);
+    expect(await inheritancePlugin.requiresToManageTransfer()).to.be.true;
     await expect(inheritancePlugin.connect(bob).setSentinel(alice.address, true, 0, 0, 0))
       .to.emit(inheritancePlugin, "SentinelUpdated")
       .withArgs(bob.address, alice.address, true);

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -35,6 +35,12 @@ const Helpers = {
     }
   },
 
+  async upgradeProxy(upgrades, address, contract) {
+    const upgraded = await upgrades.upgradeProxy(address, contract);
+    await upgraded.deployed();
+    return upgraded;
+  },
+
   async attach(chainId, contractName, contractAddress) {
     const contract = await this.ethers.getContractFactory(contractName);
     return contract.attach(contractAddress);


### PR DESCRIPTION
It is not possible to unplug a plugin, since the plugin has been deployed and associated to the NFT. But that can be necessary if a critical vulnerability is discovered in the plugin.
This PR allows the owner to disable and re-enable plugins, with the optional possibility of factory reset the plugin.