### PR TITLE
Move event from the InheritancePlugin to the ProtectedNFT when a managed transfer occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   ManagerProxy.sol              |      100 |      100 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
- contracts/plugins/inheritance/ |      100 |    71.43 |      100 |    98.75 |                |
+ contracts/plugins/inheritance/ |      100 |    71.43 |      100 |    98.73 |                |
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
-  InheritancePlugin.sol         |      100 |    71.43 |      100 |    98.73 |            179 |
+  InheritancePlugin.sol         |      100 |    71.43 |      100 |    98.72 |            179 |
   InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
- contracts/protected/           |      100 |       56 |      100 |    97.67 |                |
-  ProtectedNFT.sol              |      100 |       56 |      100 |    97.67 |             84 |
+ contracts/protected/           |      100 |       56 |      100 |    97.73 |                |
+  ProtectedNFT.sol              |      100 |       56 |      100 |    97.73 |             86 |
  contracts/utils/               |      100 |      100 |      100 |      100 |                |
   FlexiProxy.sol                |      100 |      100 |      100 |      100 |                |
   SignatureValidator.sol        |      100 |      100 |      100 |      100 |                |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 ## Test coverage
 
 ```
-  27 passing (9s)
+  27 passing (10s)
 
 --------------------------------|----------|----------|----------|----------|----------------|
 File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
@@ -163,7 +163,7 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   CrunaFlexiVault.sol           |      100 |       40 |      100 |      100 |                |
  contracts/factory/             |      100 |    55.77 |      100 |       96 |                |
   IVaultFactory.sol             |      100 |      100 |      100 |      100 |                |
-  VaultFactory.sol              |      100 |    55.77 |      100 |       96 |         67,120 |
+  VaultFactory.sol              |      100 |    55.77 |      100 |       96 |         66,119 |
  contracts/interfaces/          |      100 |      100 |      100 |      100 |                |
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |

--- a/contracts/factory/VaultFactory.sol
+++ b/contracts/factory/VaultFactory.sol
@@ -26,7 +26,6 @@ contract VaultFactory is IVaultFactory, Versioned, Initializable, PausableUpgrad
   CrunaFlexiVault public vault;
   uint256 public price;
   mapping(address => bool) public stableCoins;
-  mapping(address => uint256) public proceedsBalances;
   uint256 public discount;
   address[] private _stableCoins;
 

--- a/contracts/interfaces/IProtected.sol
+++ b/contracts/interfaces/IProtected.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 // Author: Francesco Sullo <francesco@sullo.co>
 
-// erc165 interfaceId 0x0009b66d
+// erc165 interfaceId 0xc87d16e3
 interface IProtected {
   // @dev Allow to transfer a token when at least 1 protector has been set.
   //   This is necessary because when a protector is set, the token is not
@@ -19,4 +19,10 @@ interface IProtected {
     uint256 validFor,
     bytes calldata signature
   ) external;
+
+  // @dev Allow a plugin to transfer the token
+  // @param pluginNameHash The hash of the plugin name.
+  // @param tokenId The id of the token.
+  // @param to The address of the recipient.
+  function managedTransfer(bytes32 pluginNameHash, uint256 tokenId, address to) external;
 }

--- a/contracts/manager/Manager.sol
+++ b/contracts/manager/Manager.sol
@@ -284,7 +284,7 @@ contract Manager is IManager, Actor, ManagerBase {
           revert InconsistentPolicy();
         }
         if (disabledPlugins[pluginNamesByRole[pluginRoles[i]]]) revert DisabledPlugin();
-        vault().managedTransfer(tokenId, to);
+        vault().managedTransfer(pluginNamesByRole[pluginRoles[i]], tokenId, to);
         _resetActors();
         return;
       }

--- a/contracts/manager/ManagerBase.sol
+++ b/contracts/manager/ManagerBase.sol
@@ -15,7 +15,7 @@ import {Versioned} from "../utils/Versioned.sol";
 //import {console} from "hardhat/console.sol";
 
 interface IVault {
-  function managedTransfer(uint256 tokenId, address to) external;
+  function managedTransfer(bytes32 pluginNameHash, uint256 tokenId, address to) external;
   function emitLockedEvent(uint256 tokenId, bool locked_) external;
   function guardian() external view returns (Guardian);
   function registry() external view returns (IERC6551Registry);

--- a/contracts/plugins/inheritance/IInheritancePlugin.sol
+++ b/contracts/plugins/inheritance/IInheritancePlugin.sol
@@ -22,9 +22,6 @@ interface IInheritancePlugin {
 
   event TransferRequestApproved(address indexed sentinel);
 
-  // @dev Emitted when a beneficiary inherits a token
-  event InheritedBy(address indexed beneficiary);
-
   // @dev Struct to store the configuration for the inheritance
   struct InheritanceConf {
     uint16 quorum;

--- a/contracts/plugins/inheritance/InheritancePlugin.sol
+++ b/contracts/plugins/inheritance/InheritancePlugin.sol
@@ -240,7 +240,6 @@ contract InheritancePlugin is IPlugin, IInheritancePlugin, ManagerBase {
       if (_isGracePeriodExpiredAfterStart()) revert Expired();
     }
     _reset();
-    emit InheritedBy(_msgSender());
     manager.managedTransfer(tokenId(), _msgSender());
   }
 

--- a/contracts/protected/ProtectedNFT.sol
+++ b/contracts/protected/ProtectedNFT.sol
@@ -23,6 +23,8 @@ abstract contract ProtectedNFT is IProtected, Versioned, IERC6454, IERC6982, ERC
   using ECDSA for bytes32;
   using Strings for uint256;
 
+  event ManagedTransfer(bytes32 indexed pluginNameHash, uint256 indexed tokenId);
+
   error NotTheTokenOwner();
   error TimestampInvalidOrExpired();
   error SignatureAlreadyUsed();
@@ -117,11 +119,12 @@ abstract contract ProtectedNFT is IProtected, Versioned, IERC6454, IERC6982, ERC
   }
 
   // @dev See {IProtected721-managedTransfer}.
-  function managedTransfer(uint256 tokenId, address to) external onlyManager(tokenId) {
+  function managedTransfer(bytes32 pluginNameHash, uint256 tokenId, address to) external override onlyManager(tokenId) {
     _approvedTransfers[tokenId] = true;
     _approve(managerOf(tokenId), tokenId);
     safeTransferFrom(ownerOf(tokenId), to, tokenId);
     _approve(address(0), tokenId);
+    emit ManagedTransfer(pluginNameHash, tokenId);
     delete _approvedTransfers[tokenId];
   }
 

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -3495,25 +3495,6 @@
         "type": "function"
       },
       {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "",
-            "type": "address"
-          }
-        ],
-        "name": "proceedsBalances",
-        "outputs": [
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-      },
-      {
         "inputs": [],
         "name": "proxiableUUID",
         "outputs": [

--- a/export/ABIs.json
+++ b/export/ABIs.json
@@ -1261,19 +1261,6 @@
           {
             "indexed": true,
             "internalType": "address",
-            "name": "beneficiary",
-            "type": "address"
-          }
-        ],
-        "name": "InheritedBy",
-        "type": "event"
-      },
-      {
-        "anonymous": false,
-        "inputs": [
-          {
-            "indexed": true,
-            "internalType": "address",
             "name": "owner",
             "type": "address"
           }
@@ -2040,6 +2027,25 @@
         "inputs": [
           {
             "indexed": true,
+            "internalType": "bytes32",
+            "name": "pluginNameHash",
+            "type": "bytes32"
+          },
+          {
+            "indexed": true,
+            "internalType": "uint256",
+            "name": "tokenId",
+            "type": "uint256"
+          }
+        ],
+        "name": "ManagedTransfer",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
             "internalType": "address",
             "name": "previousOwner",
             "type": "address"
@@ -2346,6 +2352,11 @@
       },
       {
         "inputs": [
+          {
+            "internalType": "bytes32",
+            "name": "pluginNameHash",
+            "type": "bytes32"
+          },
           {
             "internalType": "uint256",
             "name": "tokenId",

--- a/test/Manager.Protectors.test.js
+++ b/test/Manager.Protectors.test.js
@@ -65,7 +65,7 @@ describe("Manager : Protectors", function () {
     const vaultMock = await deployContract("VaultMock", deployer.address);
     await vaultMock.init(erc6551Registry.address, guardian.address, signatureValidator.address, proxy.address);
     const interfaceId = await vaultMock.getIProtectedInterfaceId();
-    expect(interfaceId).to.equal("0x0009b66d");
+    expect(interfaceId).to.equal("0xc87d16e3");
     expect(await vault.supportsInterface(interfaceId)).to.be.true;
   });
 


### PR DESCRIPTION
This moves the event InheritBy inside InheritancePlugin to a more general ManagedTransfer inside ProtectedNFT. The new event happens at the same time of a standard Transfer even. It expects the tokenId and the hash of the name of the plugin, allowing to know which plugin made the transfer.
Also, I re-added the managedTransfer function in the IProtectedNFT interface.