### PR TITLE
Improving executability if too many plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ npm install @cruna/protocol@1.0.0-alpha.3 @openzeppelin/contracts erc6551
 or similar commands using Yarn or Pnpm, and use in your Solidity smart contracts, for example, as
 
 ```
-import {ProtectedNFT} from "@cruna/protocol/contracts/protected/ProtectedNFT.sol";
+import {ManagedNFT} from "@cruna/protocol/contracts/protected/ManagedNFT.sol";
 
-contract MySuperToken is ProtectedNFT {
+contract MySuperToken is ManagedNFT {
    
     constructor(
     address registry_,
     address guardian_,
     address signatureValidator_,
     address managerProxy_
-  ) ProtectedNFT("My Super Token", "MST", registry_, guardian_, signatureValidator_, managerProxy_) {}
+  ) ManagedNFT("My Super Token", "MST", registry_, guardian_, signatureValidator_, managerProxy_) {}
 }
 ```
 
@@ -180,28 +180,28 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
  contracts/interfaces/          |      100 |      100 |      100 |      100 |                |
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
-  IProtected.sol                |      100 |      100 |      100 |      100 |                |
- contracts/manager/             |    96.69 |    69.15 |       94 |    96.32 |                |
+  IManagedERC721.sol            |      100 |      100 |      100 |      100 |                |
+ contracts/manager/             |     98.4 |    70.59 |      100 |    98.61 |                |
   Actor.sol                     |      100 |       70 |      100 |      100 |                |
   Guardian.sol                  |      100 |       50 |      100 |    83.33 |             21 |
   IManager.sol                  |      100 |      100 |      100 |      100 |                |
-  Manager.sol                   |    97.47 |    68.57 |       92 |    96.51 |    236,240,287 |
-  ManagerBase.sol               |       90 |       80 |    92.31 |    95.65 |             89 |
+  Manager.sol                   |    98.81 |    70.51 |      100 |    98.95 |            128 |
+  ManagerBase.sol               |    94.74 |       80 |      100 |      100 |                |
   ManagerProxy.sol              |      100 |      100 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
- contracts/plugins/inheritance/ |    98.48 |    72.37 |    95.24 |    96.67 |                |
+ contracts/plugins/inheritance/ |      100 |    72.37 |      100 |    97.67 |                |
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
-  InheritancePlugin.sol         |    98.48 |    72.37 |       95 |    96.63 |     86,182,260 |
+  InheritancePlugin.sol         |      100 |    72.37 |      100 |    97.65 |         80,176 |
   InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
- contracts/protected/           |    93.33 |    55.26 |    85.71 |    88.89 |                |
-  ProtectedNFT.sol              |    93.33 |    55.26 |    85.71 |    88.89 |   51,52,87,164 |
+ contracts/protected/           |      100 |     52.5 |      100 |    96.97 |                |
+  ManagedERC721.sol             |      100 |     52.5 |      100 |    96.97 |            158 |
  contracts/utils/               |      100 |       75 |      100 |      100 |                |
   FlexiProxy.sol                |      100 |      100 |      100 |      100 |                |
   SignatureValidator.sol        |      100 |       75 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    97.39 |     64.6 |    94.59 |    95.69 |                |
+All files                       |    99.25 |    64.79 |      100 |    97.85 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 
 ## History
 
+**1.0.0-alpha.5**
+
+- Fixes the risk that there are too many plugins and it becomes impossible to disable them all
+- Renames ProtectedNFT to ManagedERC721
+
 **1.0.0-alpha.4**
 
 - Optimize costs during signature validation

--- a/README.md
+++ b/README.md
@@ -186,27 +186,27 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
   IManagedERC721.sol            |      100 |      100 |      100 |      100 |                |
- contracts/manager/             |     98.4 |    70.59 |      100 |    98.61 |                |
+ contracts/manager/             |    98.39 |    70.59 |    97.96 |     97.9 |                |
   Actor.sol                     |      100 |       70 |      100 |      100 |                |
   Guardian.sol                  |      100 |       50 |      100 |    83.33 |             21 |
   IManager.sol                  |      100 |      100 |      100 |      100 |                |
-  Manager.sol                   |    98.81 |    70.51 |      100 |    98.95 |            128 |
+  Manager.sol                   |     98.8 |    70.51 |      100 |    98.94 |            127 |
   ManagerBase.sol               |    94.74 |       80 |      100 |      100 |                |
-  ManagerProxy.sol              |      100 |      100 |      100 |      100 |                |
+  ManagerProxy.sol              |      100 |      100 |        0 |        0 |             10 |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
- contracts/plugins/inheritance/ |      100 |    72.37 |      100 |    97.67 |                |
+ contracts/plugins/inheritance/ |      100 |    72.37 |    94.74 |    96.51 |                |
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
   InheritancePlugin.sol         |      100 |    72.37 |      100 |    97.65 |         80,176 |
-  InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
+  InheritancePluginProxy.sol    |      100 |      100 |        0 |        0 |             10 |
  contracts/protected/           |      100 |     52.5 |      100 |    96.97 |                |
   ManagedERC721.sol             |      100 |     52.5 |      100 |    96.97 |            158 |
- contracts/utils/               |      100 |       75 |      100 |      100 |                |
-  FlexiProxy.sol                |      100 |      100 |      100 |      100 |                |
+ contracts/utils/               |    83.33 |       75 |      100 |    83.33 |                |
+  FlexiProxy.sol                |        0 |      100 |      100 |        0 |             13 |
   SignatureValidator.sol        |      100 |       75 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    99.25 |    64.79 |      100 |    97.85 |                |
+All files                       |    98.87 |    64.79 |    98.11 |    96.92 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/contracts/CrunaFlexiVault.sol
+++ b/contracts/CrunaFlexiVault.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL3
 pragma solidity ^0.8.20;
 
-import {ProtectedNFT, Strings} from "./protected/ProtectedNFT.sol";
+import {ManagedERC721, Strings} from "./protected/ManagedERC721.sol";
 
 //import "hardhat/console.sol";
 
 // @dev This contract is a simple example of a protected NFT.
-contract CrunaFlexiVault is ProtectedNFT {
+contract CrunaFlexiVault is ManagedERC721 {
   using Strings for uint256;
 
   error NotTheFactory();
@@ -25,7 +25,7 @@ contract CrunaFlexiVault is ProtectedNFT {
   //   using Nick's factory, so we may in theory hardcode them in the code. However,
   //   if so, we will not be able to test the contract.
   // @param owner The address of the owner.
-  constructor(address owner) ProtectedNFT("Cruna Flexi Vault V1", "CRUNA1", owner) {}
+  constructor(address owner) ManagedERC721("Cruna Flexi Vault V1", "CRUNA1", owner) {}
 
   // @dev Set factory to 0x0 to disable a factory.
   // @notice This is the only function that can be called by the owner.

--- a/contracts/interfaces/IManagedERC721.sol
+++ b/contracts/interfaces/IManagedERC721.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 // Author: Francesco Sullo <francesco@sullo.co>
 
 // erc165 interfaceId 0xe19a64da
-interface IProtected {
+interface IManagedERC721 {
   // @dev Allow a plugin to transfer the token
   // @param pluginNameHash The hash of the plugin name.
   // @param tokenId The id of the token.

--- a/contracts/manager/IManager.sol
+++ b/contracts/manager/IManager.sol
@@ -15,12 +15,22 @@ interface IManager {
 
   event PluginStatusChange(string name, address plugin, bool status);
 
+  event LockFailed(uint256 tokenId, bool status);
+
+  event AllPluginsDisabled();
+
   struct Plugin {
     address proxyAddress;
-    bool active;
+    bool canManageTransfer;
   }
 
-  function plug(string memory name, address implementation) external;
+  struct DisabledPlugin {
+    address proxyAddress;
+    bool canManageTransfer;
+    string name;
+  }
+
+  function plug(string memory name, address implementation, bool canManageTransfer) external;
 
   function disablePlugin(string memory name, bool resetPlugin) external;
 

--- a/contracts/manager/Manager.sol
+++ b/contracts/manager/Manager.sol
@@ -35,14 +35,17 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
   error WrongDataOrNotSignedByProtector();
   error CannotBeYourself();
   error NotTheAuthorizedPlugin();
-  error PluginAlreadyPlugged();
+  error SignatureAlreadyUsed();
   error NotAProxy();
   error ContractsCannotBeProtectors();
-  error PluginNotFound();
   error InconsistentPolicy();
+  error PluginAlreadyPlugged();
+  error PluginAlreadyPluggedButDisabled();
+  error PluginNotFound();
   error PluginNotFoundOrDisabled();
-  error RoleNotAuthorizedFor(bytes4 role, bytes4 pluginNameHash);
-  error SignatureAlreadyUsed();
+  error PluginNotDisabled();
+  error PluginAlreadyDisabled();
+  error PluginNotAuthorizedToManageTransfer();
 
   mapping(bytes32 => bool) public usedSignatures;
   bytes4 public constant PROTECTOR = bytes4(keccak256("PROTECTOR"));
@@ -51,7 +54,8 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
   bytes32 public constant SALT = bytes32(uint256(69));
 
   mapping(bytes4 => Plugin) public pluginsByName;
-  string[] public pluginNames;
+  mapping(bytes4 => DisabledPlugin) public disabledPluginsByName;
+  string[] public activePlugins;
 
   function nameHash() public virtual override returns (bytes4) {
     return bytes4(keccak256("Manager"));
@@ -100,12 +104,28 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
     emit ProtectorUpdated(_msgSender(), protector_, status);
     if (status) {
       if (countActiveProtectors() == 1) {
-        vault().emitLockedEvent(tokenId(), true);
+        _emitLockedEvent(true);
       }
     } else {
       if (countActiveProtectors() == 0) {
-        vault().emitLockedEvent(tokenId(), false);
+        _emitLockedEvent(false);
       }
+    }
+  }
+
+  function _emitLockedEvent(bool locked_) internal virtual {
+    // Avoid to revert if the emission of the event fails.
+    // It should never happen, but if it happens, we are
+    // notified by the LockFailed event, instead of reverting
+    // the entire transaction.
+    bytes memory data = abi.encodeWithSignature("emitLockedEvent(uint256,bool)", tokenId(), locked_);
+    address vaultAddress = address(vault());
+    // solhint-disable-next-line avoid-low-level-calls
+    (, bytes memory returnData) = vaultAddress.call(data);
+    (bool success, ) = vaultAddress.call(data);
+    if (!success) {
+      // this way we can ask the user to execute an explicit lock
+      emit LockFailed(tokenId(), locked_);
     }
   }
 
@@ -212,93 +232,110 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
    *
    */
 
-  function plug(string memory name, address pluginProxy) external virtual override onlyTokenOwner nonReentrant {
+  function plug(
+    string memory name,
+    address pluginProxy,
+    bool canManageTransfer
+  ) external virtual override onlyTokenOwner nonReentrant {
     try IProxy(pluginProxy).isProxy() returns (bool) {} catch {
       revert NotAProxy();
     }
-    bytes4 _nameHash = bytes4(keccak256(abi.encodePacked(name)));
+    bytes4 _nameHash = _stringToBytes4(name);
     if (pluginsByName[_nameHash].proxyAddress != address(0)) revert PluginAlreadyPlugged();
-    pluginsByName[_nameHash] = Plugin(pluginProxy, true);
-    pluginNames.push(name);
+    if (disabledPluginsByName[_nameHash].proxyAddress != address(0)) revert PluginAlreadyPluggedButDisabled();
+    pluginsByName[_nameHash] = Plugin(pluginProxy, canManageTransfer);
+    activePlugins.push(name);
     if (!guardian().isTrustedImplementation(_nameHash, pluginProxy)) revert InvalidImplementation();
     registry().createAccount(pluginProxy, SALT, block.chainid, address(this), tokenId());
     IPluginExt _plugin = plugin(_nameHash);
+    if (!canManageTransfer && _plugin.requiresToManageTransfer()) {
+      revert InconsistentPolicy();
+    }
     if (_plugin.nameHash() != _nameHash) revert InvalidImplementation();
     emit PluginStatusChange(name, address(_plugin), true);
     _plugin.init();
   }
 
+  function pluginAddress(bytes4 _nameHash) public view virtual returns (address) {
+    return registry().account(pluginsByName[_nameHash].proxyAddress, SALT, block.chainid, address(this), tokenId());
+  }
+
   function plugin(bytes4 _nameHash) public view virtual returns (IPluginExt) {
-    return IPluginExt(registry().account(pluginsByName[_nameHash].proxyAddress, SALT, block.chainid, address(this), tokenId()));
+    return IPluginExt(pluginAddress(_nameHash));
   }
 
-  function pluginRoles(bytes4 _nameHash) public view virtual returns (bytes4[] memory) {
-    return plugin(_nameHash).pluginRoles();
-  }
-
-  function isPluginSRole(bytes4 _nameHash, bytes4 role) public view virtual returns (bool) {
-    return plugin(_nameHash).isPluginSRole(role);
-  }
-
-  // Plugin cannot be unplugged since they have been deployed via ERC-6551 Registry
-  // so, we mark them as disabled
+  // Plugin cannot be deleted since they have been deployed
+  // via ERC-6551 Registry so, we remove from the list of
+  // the active plugins.
   function disablePlugin(string memory name, bool resetPlugin) external virtual override onlyTokenOwner nonReentrant {
-    bytes4 _nameHash = bytes4(keccak256(abi.encodePacked(name)));
+    bytes4 _nameHash = _stringToBytes4(name);
+    if (disabledPluginsByName[_nameHash].proxyAddress != address(0)) revert PluginAlreadyDisabled();
     if (pluginsByName[_nameHash].proxyAddress == address(0)) revert PluginNotFound();
-    pluginsByName[_nameHash].active = false;
     if (resetPlugin) {
       _resetPlugin(_nameHash);
     }
-    emit PluginStatusChange(name, address(plugin(_nameHash)), false);
+    emit PluginStatusChange(name, pluginAddress(_nameHash), false);
+    disabledPluginsByName[_nameHash] = DisabledPlugin(
+      pluginsByName[_nameHash].proxyAddress,
+      pluginsByName[_nameHash].canManageTransfer,
+      name
+    );
+    delete pluginsByName[_nameHash];
+    // Delete it to help in case there are too many plugins and
+    // the reset fails because of gas limit.
+    for (uint256 i = 0; i < activePlugins.length; i++) {
+      if (_stringToBytes4(activePlugins[i]) == _nameHash) {
+        activePlugins[i] = activePlugins[activePlugins.length - 1];
+        break;
+      }
+    }
+    activePlugins.pop();
+  }
+
+  function _stringToBytes4(string memory str) internal pure returns (bytes4) {
+    return bytes4(keccak256(abi.encodePacked(str)));
   }
 
   function reEnablePlugin(string memory name, bool resetPlugin) external virtual override onlyTokenOwner nonReentrant {
-    bytes4 _nameHash = bytes4(keccak256(abi.encodePacked(name)));
-    if (pluginsByName[_nameHash].proxyAddress == address(0) || pluginsByName[_nameHash].active) revert PluginNotFound();
-    pluginsByName[_nameHash].active = true;
+    bytes4 _nameHash = _stringToBytes4(name);
+    if (disabledPluginsByName[_nameHash].proxyAddress == address(0)) revert PluginNotDisabled();
+    pluginsByName[_nameHash] = Plugin(
+      disabledPluginsByName[_nameHash].proxyAddress,
+      disabledPluginsByName[_nameHash].canManageTransfer
+    );
+    activePlugins.push(disabledPluginsByName[_nameHash].name);
+    delete disabledPluginsByName[_nameHash];
     if (resetPlugin) {
       _resetPlugin(_nameHash);
     }
-    emit PluginStatusChange(name, address(plugin(_nameHash)), true);
+    emit PluginStatusChange(name, pluginAddress(_nameHash), true);
   }
 
   function _resetPlugin(bytes4 _nameHash) internal virtual {
     IPluginExt _plugin = plugin(_nameHash);
-    bytes4[] memory roles = _plugin.pluginRoles();
-    for (uint256 i = 0; i < roles.length; i++) {
-      _deleteActors(roles[i]);
-    }
     _plugin.reset();
-  }
-
-  function _authorizedPlugin(bytes4 pluginNameHash) internal view virtual returns (IPluginExt) {
-    if (!pluginsByName[pluginNameHash].active) revert PluginNotFoundOrDisabled();
-    IPluginExt _plugin = plugin(pluginNameHash);
-    if (address(_plugin) != _msgSender()) revert NotTheAuthorizedPlugin();
-    return _plugin;
   }
 
   // @dev See {IProtected721-managedTransfer}.
   // This is a special function that can be called only by the InheritancePlugin
   function managedTransfer(bytes4 pluginNameHash, uint256 tokenId, address to) external virtual override nonReentrant {
-    IPluginExt _plugin = _authorizedPlugin(pluginNameHash);
-    if (!_plugin.requiresToManageTransfer()) {
-      // The plugin declares itself as not requiring the ability to manage transfers, but in reality it is trying to do so
-      revert InconsistentPolicy();
-    }
+    if (pluginsByName[pluginNameHash].proxyAddress == address(0)) revert PluginNotFoundOrDisabled();
+    if (!pluginsByName[pluginNameHash].canManageTransfer) revert PluginNotAuthorizedToManageTransfer();
+    if (pluginAddress(pluginNameHash) != _msgSender()) revert NotTheAuthorizedPlugin();
     _resetActorsAndDisablePlugins();
+    // In theory, the vault may revert, blocking the entire process
+    // We allow it, assuming that the vault implementation has the
+    // right to set up more advanced rules, before allowing the transfer,
+    // despite the plugin has the ability to do so.
     vault().managedTransfer(pluginNameHash, tokenId, to);
   }
 
   function _resetActorsAndDisablePlugins() internal virtual {
     _deleteActors(PROTECTOR);
     _deleteActors(SAFE_RECIPIENT);
-    for (uint256 i = 0; i < pluginNames.length; i++) {
-      bytes4 _nameHash = bytes4(keccak256(abi.encodePacked(pluginNames[i])));
-      if (pluginsByName[_nameHash].active) {
-        delete pluginsByName[_nameHash].active;
-        emit PluginStatusChange(pluginNames[i], address(plugin(_nameHash)), false);
-      }
+    if (activePlugins.length > 0) {
+      delete activePlugins;
+      emit AllPluginsDisabled();
     }
   }
 
@@ -308,7 +345,7 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
     uint256 timeValidation,
     bytes calldata signature
   ) external onlyTokenOwner {
-    _validateAndCheckSignature(nameHash(), bytes4(keccak256("protectedTransfer")), to, false, timeValidation, signature);
+    _validateAndCheckSignature(nameHash(), _stringToBytes4("protectedTransfer"), to, false, timeValidation, signature);
     _resetActorsAndDisablePlugins();
     vault().managedTransfer(nameHash(), tokenId, to);
   }

--- a/contracts/manager/Manager.sol
+++ b/contracts/manager/Manager.sol
@@ -121,7 +121,6 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
     bytes memory data = abi.encodeWithSignature("emitLockedEvent(uint256,bool)", tokenId(), locked_);
     address vaultAddress = address(vault());
     // solhint-disable-next-line avoid-low-level-calls
-    (, bytes memory returnData) = vaultAddress.call(data);
     (bool success, ) = vaultAddress.call(data);
     if (!success) {
       // this way we can ask the user to execute an explicit lock

--- a/contracts/manager/ManagerBase.sol
+++ b/contracts/manager/ManagerBase.sol
@@ -85,10 +85,6 @@ abstract contract ManagerBase is Context, Versioned {
     return (bytes32(a) >> 192) | (bytes32(b) >> 224);
   }
 
-  function combineBytes4AndString(bytes4 a, string memory b) public pure returns (bytes32) {
-    return (bytes32(a) >> 192) | (bytes32(bytes4(keccak256(abi.encodePacked(b)))) >> 224);
-  }
-
   // @dev Upgrade the implementation of the manager/plugin
   //   Notice that the owner can upgrade active or disable plugins
   //   so that, if a plugin is compromised, the user can disable it,

--- a/contracts/mocks/VaultMock.sol
+++ b/contracts/mocks/VaultMock.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.0;
 
 import {CrunaFlexiVault} from "../CrunaFlexiVault.sol";
-import {IProtected} from "../interfaces/IProtected.sol";
+import {IManagedERC721} from "../interfaces/IManagedERC721.sol";
 
 contract VaultMock is CrunaFlexiVault {
   constructor(address owner) CrunaFlexiVault(owner) {}
 
   function getIProtectedInterfaceId() external pure returns (bytes4) {
-    return type(IProtected).interfaceId;
+    return type(IManagedERC721).interfaceId;
   }
 }

--- a/contracts/mocks/plugin-example/simple/SomeSimplePlugin.sol
+++ b/contracts/mocks/plugin-example/simple/SomeSimplePlugin.sol
@@ -35,13 +35,6 @@ contract SomeSimplePlugin is IPlugin, ManagerBase {
     return bytes4(keccak256("SomeSimplePlugin"));
   }
 
-  function pluginRoles() external pure virtual returns (bytes4[] memory) {
-    bytes4[] memory roles = new bytes4[](1);
-    // return your roles, if any
-    roles[0] = SOME_ROLE;
-    return roles;
-  }
-
   function doSomething() external {
     // some logic
   }
@@ -57,9 +50,5 @@ contract SomeSimplePlugin is IPlugin, ManagerBase {
 
   function _reset() internal {
     // reset to initial state
-  }
-
-  function isPluginSRole(bytes4 role) external pure override returns (bool) {
-    return role == SOME_ROLE;
   }
 }

--- a/contracts/mocks/plugin-example/upgradeable/SomePlugin.sol
+++ b/contracts/mocks/plugin-example/upgradeable/SomePlugin.sol
@@ -29,13 +29,6 @@ contract SomePlugin is IPlugin, ManagerBase {
     manager = Manager(_msgSender());
   }
 
-  function pluginRoles() external pure virtual returns (bytes4[] memory) {
-    bytes4[] memory roles = new bytes4[](1);
-    // return your roles, if any
-    roles[0] = SOME_OTHER_ROLE;
-    return roles;
-  }
-
   function doSomething() external {
     // some logic
   }
@@ -47,10 +40,6 @@ contract SomePlugin is IPlugin, ManagerBase {
 
   function _reset() internal {
     // reset to initial state
-  }
-
-  function isPluginSRole(bytes4 role) external pure override returns (bool) {
-    return role == SOME_OTHER_ROLE;
   }
 
   // @dev This empty reserved space is put in place to allow future versions to add new

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/protocol",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "The Cruna protocol",
   "publishConfig": {
     "access": "public"

--- a/contracts/plugins/IPlugin.sol
+++ b/contracts/plugins/IPlugin.sol
@@ -10,14 +10,10 @@ pragma solidity ^0.8.9;
 interface IPlugin {
   function init() external;
 
-  function pluginRoles() external view returns (bytes4[] memory);
-
   // function called in the dashboard to know if the plugin is asking the
   // right to make a managed transfer of the vault
   function requiresToManageTransfer() external pure returns (bool);
 
   // Reset the plugin to the factory settings
   function reset() external;
-
-  function isPluginSRole(bytes4 role) external view returns (bool);
 }

--- a/contracts/plugins/inheritance/InheritancePlugin.sol
+++ b/contracts/plugins/inheritance/InheritancePlugin.sol
@@ -59,12 +59,6 @@ contract InheritancePlugin is IPlugin, IInheritancePlugin, ManagerBase, Actor, S
     return bytes4(keccak256("InheritancePlugin"));
   }
 
-  function pluginRoles() external pure virtual returns (bytes4[] memory) {
-    bytes4[] memory roles = new bytes4[](1);
-    roles[0] = SENTINEL;
-    return roles;
-  }
-
   // sentinels and beneficiaries
   // @dev see {IInheritancePlugin.sol-setSentinel}
   function setSentinel(
@@ -254,10 +248,6 @@ contract InheritancePlugin is IPlugin, IInheritancePlugin, ManagerBase, Actor, S
   function _reset() internal {
     _deleteActors(SENTINEL);
     delete _inheritanceConf;
-  }
-
-  function isPluginSRole(bytes4 role) external pure override returns (bool) {
-    return role == SENTINEL;
   }
 
   // @dev Validates the request.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/protocol",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "description": "The Cruna protocol",
   "publishConfig": {
     "access": "public"

--- a/test/ContractsDevelopment.test.js
+++ b/test/ContractsDevelopment.test.js
@@ -55,6 +55,9 @@ describe("Testing contract deployments", function () {
 
   it("should deploy everything as expected", async function () {
     // test the beforeEach
+    // to cover it
+    const flexiProxy = await deployContract("FlexiProxy", managerImpl.address);
+    expect(await flexiProxy.isProxy()).to.be.true;
   });
 
   it("should get the token parameters from the manager", async function () {

--- a/test/InheritanceManager.Sentinels.test.js
+++ b/test/InheritanceManager.Sentinels.test.js
@@ -65,14 +65,20 @@ describe("Sentinel and Inheritance", function () {
     const manager = await ethers.getContractAt("Manager", await vault.managerOf(nextTokenId));
     inheritancePluginImpl = await deployContract("InheritancePlugin");
     inheritancePluginProxy = await deployContract("InheritancePluginProxy", inheritancePluginImpl.address);
-    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginImpl.address)).to.be.revertedWith("NotAProxy");
-    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address)).to.be.revertedWith(
+    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginImpl.address, true)).to.be.revertedWith(
+      "NotAProxy",
+    );
+    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address, true)).to.be.revertedWith(
       "InvalidImplementation",
     );
     const nameHash = bytes4(keccak256("InheritancePlugin"));
     await guardian.setTrustedImplementation(nameHash, inheritancePluginProxy.address, true);
     expect((await manager.pluginsByName(nameHash)).proxyAddress).to.equal(addr0);
-    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address)).to.emit(
+    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address, false)).to.be.revertedWith(
+      "InconsistentPolicy",
+    );
+
+    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address, true)).to.emit(
       manager,
       "PluginStatusChange",
     );

--- a/test/Manager.Protectors.test.js
+++ b/test/Manager.Protectors.test.js
@@ -63,7 +63,7 @@ describe("Manager : Protectors", function () {
     return nextTokenId;
   };
 
-  it("should support the IProtected interface", async function () {
+  it("should support the IManagedERC721.sol interface", async function () {
     const vaultMock = await deployContract("VaultMock", deployer.address);
     await vaultMock.init(erc6551Registry.address, guardian.address, proxy.address);
     const interfaceId = await vaultMock.getIProtectedInterfaceId();
@@ -91,6 +91,7 @@ describe("Manager : Protectors", function () {
     expect(await vault.locked(tokenId)).to.be.false;
     expect(await vault.isTransferable(tokenId, bob.address, addr0)).to.be.false;
     expect(await vault.isTransferable(tokenId, bob.address, bob.address)).to.be.false;
+    expect(await vault.isTransferable(tokenId, bob.address, fred.address)).to.be.true;
   });
 
   it("should verify that scope is correctly formed", async function () {


### PR DESCRIPTION
Fix a out-of-gas risk, removing disabled plugins from the array that lists them, listing only the active ones. This requires a new mapping to save the name of the disabled plugin, but it is a reasonable trade off between costs and safety.
It also renames the base NFT from ProtectedNFT to ManagedERC721 since the command protectedTransfer has been removed from the NFT, leaving only managedTransfer, and put inside the Manager.