### PR TITLE
Decouple minting of a new vault from its activation

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ["mocks", "erc6551"],
+  skipFiles: ["mocks", "untested"],
 };

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 
 ## History
 
+**1.0.0-alpha.6**
+
+- Decouples the minting of a vault from its activation
+- Add `activate` to later activate the vault, creating a manager for the tokenId
+
 **1.0.0-alpha.5**
 
 - Fixes the risk that there are too many plugins and it becomes impossible to disable them all

--- a/README.md
+++ b/README.md
@@ -172,18 +172,18 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 ## Test coverage
 
 ```
-  30 passing
+  31 passing
 
 --------------------------------|----------|----------|----------|----------|----------------|
 File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 --------------------------------|----------|----------|----------|----------|----------------|
  contracts/                     |      100 |       40 |      100 |      100 |                |
   CrunaFlexiVault.sol           |      100 |       40 |      100 |      100 |                |
- contracts/factory/             |      100 |    55.77 |      100 |       96 |                |
+ contracts/factory/             |      100 |    55.36 |      100 |    95.83 |                |
   IVaultFactory.sol             |      100 |      100 |      100 |      100 |                |
-  VaultFactory.sol              |      100 |    55.77 |      100 |       96 |         66,119 |
+  VaultFactory.sol              |      100 |    55.36 |      100 |    95.83 |         75,127 |
  contracts/interfaces/          |      100 |      100 |      100 |      100 |                |
-  IBondContract.sol             |      100 |      100 |      100 |      100 |                |
+  IBoundContract.sol            |      100 |      100 |      100 |      100 |                |
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
   IManagedERC721.sol            |      100 |      100 |      100 |      100 |                |
@@ -200,15 +200,15 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
   InheritancePlugin.sol         |      100 |    72.37 |      100 |    97.65 |         80,176 |
   InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
- contracts/protected/           |      100 |     52.5 |      100 |    96.97 |                |
-  ManagedERC721.sol             |      100 |     52.5 |      100 |    96.97 |            158 |
+ contracts/protected/           |      100 |    54.35 |      100 |    95.45 |                |
+  ManagedERC721.sol             |      100 |    54.35 |      100 |    95.45 |        164,176 |
  contracts/utils/               |      100 |       75 |      100 |      100 |                |
   CrunaRegistry.sol             |      100 |      100 |      100 |      100 |                |
   FlexiProxy.sol                |      100 |      100 |      100 |      100 |                |
   SignatureValidator.sol        |      100 |       75 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    97.41 |    62.33 |    99.08 |    96.36 |                |
+All files                       |    97.47 |    62.25 |     99.1 |    96.17 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ If your goal is to build a plugin, look at the contracts in [contracts/mocks/plu
 
 **1.0.0-alpha.5**
 
-- Fixes the risk that there are too many plugins and it becomes impossible to disable them all
+- Fixes the risk that there are too many plugins, and it becomes impossible to disable them all
 - Renames ProtectedNFT to ManagedERC721
 
 **1.0.0-alpha.4**

--- a/README.md
+++ b/README.md
@@ -183,30 +183,32 @@ File                            |  % Stmts | % Branch |  % Funcs |  % Lines |Unc
   IVaultFactory.sol             |      100 |      100 |      100 |      100 |                |
   VaultFactory.sol              |      100 |    55.77 |      100 |       96 |         66,119 |
  contracts/interfaces/          |      100 |      100 |      100 |      100 |                |
+  IBondContract.sol             |      100 |      100 |      100 |      100 |                |
   IERC6454.sol                  |      100 |      100 |      100 |      100 |                |
   IERC6982.sol                  |      100 |      100 |      100 |      100 |                |
   IManagedERC721.sol            |      100 |      100 |      100 |      100 |                |
- contracts/manager/             |    98.39 |    70.59 |    97.96 |     97.9 |                |
+ contracts/manager/             |    94.53 |    63.64 |       98 |    95.21 |                |
   Actor.sol                     |      100 |       70 |      100 |      100 |                |
   Guardian.sol                  |      100 |       50 |      100 |    83.33 |             21 |
   IManager.sol                  |      100 |      100 |      100 |      100 |                |
-  Manager.sol                   |     98.8 |    70.51 |      100 |    98.94 |            127 |
+  Manager.sol                   |     93.1 |    61.63 |    96.15 |    93.81 |... 259,260,262 |
   ManagerBase.sol               |    94.74 |       80 |      100 |      100 |                |
-  ManagerProxy.sol              |      100 |      100 |        0 |        0 |             10 |
+  ManagerProxy.sol              |      100 |      100 |      100 |      100 |                |
  contracts/plugins/             |      100 |      100 |      100 |      100 |                |
   IPlugin.sol                   |      100 |      100 |      100 |      100 |                |
- contracts/plugins/inheritance/ |      100 |    72.37 |    94.74 |    96.51 |                |
+ contracts/plugins/inheritance/ |      100 |    72.37 |      100 |    97.67 |                |
   IInheritancePlugin.sol        |      100 |      100 |      100 |      100 |                |
   InheritancePlugin.sol         |      100 |    72.37 |      100 |    97.65 |         80,176 |
-  InheritancePluginProxy.sol    |      100 |      100 |        0 |        0 |             10 |
+  InheritancePluginProxy.sol    |      100 |      100 |      100 |      100 |                |
  contracts/protected/           |      100 |     52.5 |      100 |    96.97 |                |
   ManagedERC721.sol             |      100 |     52.5 |      100 |    96.97 |            158 |
- contracts/utils/               |    83.33 |       75 |      100 |    83.33 |                |
-  FlexiProxy.sol                |        0 |      100 |      100 |        0 |             13 |
+ contracts/utils/               |      100 |       75 |      100 |      100 |                |
+  CrunaRegistry.sol             |      100 |      100 |      100 |      100 |                |
+  FlexiProxy.sol                |      100 |      100 |      100 |      100 |                |
   SignatureValidator.sol        |      100 |       75 |      100 |      100 |                |
   Versioned.sol                 |      100 |      100 |      100 |      100 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
-All files                       |    98.87 |    64.79 |    98.11 |    96.92 |                |
+All files                       |    97.41 |    62.33 |    99.08 |    96.36 |                |
 --------------------------------|----------|----------|----------|----------|----------------|
 ```
 

--- a/contracts/CrunaFlexiVault.sol
+++ b/contracts/CrunaFlexiVault.sol
@@ -39,12 +39,12 @@ contract CrunaFlexiVault is ManagedERC721 {
 
   // @dev This function will return the base URI of the contract
   function _baseURI() internal view virtual override returns (string memory) {
-    return "https://meta.cruna.cc/flexy-vault/v1/";
+    return "https://meta.cruna.cc/flexi-vault/v1/";
   }
 
   // @dev This function will return the contract URI of the contract
   function contractURI() public view virtual returns (string memory) {
-    return "https://meta.cruna.cc/flexy-vault/v1/info";
+    return "https://meta.cruna.cc/flexi-vault/v1/info";
   }
 
   // @dev This function will mint a new token

--- a/contracts/CrunaFlexiVault.sol
+++ b/contracts/CrunaFlexiVault.sol
@@ -49,7 +49,7 @@ contract CrunaFlexiVault is ManagedERC721 {
 
   // @dev This function will mint a new token
   // @param to The address of the recipient
-  function safeMint(address to) public virtual onlyFactory {
-    _mintAndInit(to);
+  function safeMint(address to, bool alsoInit, uint256 amount) public virtual onlyFactory {
+    _mintAndActivate(to, alsoInit, amount);
   }
 }

--- a/contracts/factory/IVaultFactory.sol
+++ b/contracts/factory/IVaultFactory.sol
@@ -35,9 +35,9 @@ interface IVaultFactory {
   // @param stableCoin the payment token to use for the purchase
   // @param amount number to buy
 
-  function buyVaults(address stableCoin, uint256 amount) external;
+  function buyVaults(address stableCoin, uint256 amount, bool alsoInit) external;
 
-  function buyVaultsBatch(address stableCoin, address[] memory tos, uint256[] memory amounts) external;
+  function buyVaultsBatch(address stableCoin, address[] memory tos, uint256[] memory amounts, bool alsoInit) external;
 
   // @dev Given a payment token, transfers amount or full balance from proceeds to an address
   // @param beneficiary address of the beneficiary

--- a/contracts/interfaces/IBondContract.sol
+++ b/contracts/interfaces/IBondContract.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// this is a reduction of IERC6551Account focusing purely on the Bond between the NFT and the contract
+
+/// @dev the ERC-165 identifier for this interface is `0xfc0c546a`
+interface IBondContract {
+  /**
+   * @dev Returns the identifier of the non-fungible token which owns the contract.
+   *
+   * The return value of this function MUST be constant - it MUST NOT change over time.
+   *
+   * @return chainId       The EIP-155 ID of the chain the token exists on
+   * @return tokenContract The contract address of the token
+   * @return tokenId       The ID of the token
+   */
+  function token() external view returns (uint256 chainId, address tokenContract, uint256 tokenId);
+}

--- a/contracts/interfaces/IBoundContract.sol
+++ b/contracts/interfaces/IBoundContract.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// this is a reduction of IERC6551Account focusing purely on the Bond between the NFT and the contract
+// this is a reduction of IERC6551Account focusing purely on the bond between the NFT and the contract
 
 /// @dev the ERC-165 identifier for this interface is `0xfc0c546a`
-interface IBondContract {
+interface IBoundContract {
   /**
    * @dev Returns the identifier of the non-fungible token which owns the contract.
    *

--- a/contracts/manager/Manager.sol
+++ b/contracts/manager/Manager.sol
@@ -246,7 +246,7 @@ contract Manager is IManager, Actor, ManagerBase, ReentrancyGuard, SignatureVali
     pluginsByName[_nameHash] = Plugin(pluginProxy, canManageTransfer);
     activePlugins.push(name);
     if (!guardian().isTrustedImplementation(_nameHash, pluginProxy)) revert InvalidImplementation();
-    address _pluginAddress = registry().createBondContract(pluginProxy, SALT, block.chainid, address(this), tokenId());
+    address _pluginAddress = registry().createBoundContract(pluginProxy, SALT, block.chainid, address(this), tokenId());
     IPluginExt _plugin = IPluginExt(_pluginAddress);
     if (_plugin.nameHash() != _nameHash) revert InvalidImplementation();
     emit PluginStatusChange(name, address(_plugin), true);

--- a/contracts/manager/ManagerBase.sol
+++ b/contracts/manager/ManagerBase.sol
@@ -8,7 +8,7 @@ import {ERC6551AccountLib} from "erc6551/lib/ERC6551AccountLib.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 
-import {IBondContract} from "../interfaces/IBondContract.sol";
+import {IBoundContract} from "../interfaces/IBoundContract.sol";
 import {ICrunaRegistry} from "../utils/CrunaRegistry.sol";
 import {Guardian} from "./Guardian.sol";
 import {Versioned} from "../utils/Versioned.sol";
@@ -26,7 +26,7 @@ interface IVault {
   @title ManagerBase
   @dev Base contract for managers and plugins
 */
-abstract contract ManagerBase is Context, IBondContract, Versioned {
+abstract contract ManagerBase is Context, IBoundContract, Versioned {
   error NotTheTokenOwner();
   error InvalidImplementation();
   error InvalidVersion();

--- a/contracts/manager/ManagerBase.sol
+++ b/contracts/manager/ManagerBase.sol
@@ -5,9 +5,11 @@ pragma solidity ^0.8.20;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import {ERC6551AccountLib} from "erc6551/lib/ERC6551AccountLib.sol";
-import {IERC6551Registry} from "erc6551/interfaces/IERC6551Registry.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+
+import {IBondContract} from "../interfaces/IBondContract.sol";
+import {ICrunaRegistry} from "../utils/CrunaRegistry.sol";
 import {Guardian} from "./Guardian.sol";
 import {Versioned} from "../utils/Versioned.sol";
 
@@ -17,14 +19,14 @@ interface IVault {
   function managedTransfer(bytes4 pluginNameHash, uint256 tokenId, address to) external;
   function emitLockedEvent(uint256 tokenId, bool locked_) external;
   function guardian() external view returns (Guardian);
-  function registry() external view returns (IERC6551Registry);
+  function registry() external view returns (ICrunaRegistry);
 }
 
 /**
   @title ManagerBase
   @dev Base contract for managers and plugins
 */
-abstract contract ManagerBase is Context, Versioned {
+abstract contract ManagerBase is Context, IBondContract, Versioned {
   error NotTheTokenOwner();
   error InvalidImplementation();
   error InvalidVersion();
@@ -48,7 +50,7 @@ abstract contract ManagerBase is Context, Versioned {
     return vault().guardian();
   }
 
-  function registry() public view virtual returns (IERC6551Registry) {
+  function registry() public view virtual returns (ICrunaRegistry) {
     return vault().registry();
   }
 
@@ -61,7 +63,7 @@ abstract contract ManagerBase is Context, Versioned {
     _;
   }
 
-  function token() public view virtual returns (uint256, address, uint256) {
+  function token() public view virtual override returns (uint256, address, uint256) {
     return ERC6551AccountLib.token();
   }
 

--- a/contracts/mocks/ERC6551RegistryMock.sol
+++ b/contracts/mocks/ERC6551RegistryMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ERC6551Registry} from "erc6551/ERC6551Registry.sol";
+import {CrunaRegistry} from "../utils/CrunaRegistry.sol";
 
-contract ERC6551RegistryMock is ERC6551Registry {}
+contract CrunaRegistryMock is CrunaRegistry {}

--- a/contracts/mocks/ValidatorMock.sol
+++ b/contracts/mocks/ValidatorMock.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {SignatureValidator} from "../utils/SignatureValidator.sol";
+
+contract ValidatorMock is SignatureValidator {}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/protocol",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "The Cruna protocol",
   "publishConfig": {
     "access": "public"

--- a/contracts/protected/ManagedERC721.sol
+++ b/contracts/protected/ManagedERC721.sol
@@ -8,7 +8,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {Guardian} from "../manager/Guardian.sol";
-import {IERC6551Registry} from "erc6551/interfaces/IERC6551Registry.sol";
+import {ICrunaRegistry} from "../utils/CrunaRegistry.sol";
 import {IManagedERC721} from "../interfaces/IManagedERC721.sol";
 import {IERC6454} from "../interfaces/IERC6454.sol";
 import {IERC6982} from "../interfaces/IERC6982.sol";
@@ -34,7 +34,7 @@ abstract contract ManagedERC721 is IManagedERC721, Versioned, IERC6454, IERC6982
 
   mapping(bytes32 => bool) public usedSignatures;
   Guardian public guardian;
-  IERC6551Registry public registry;
+  ICrunaRegistry public registry;
   Manager public managerProxy;
 
   bytes32 public constant SALT = bytes32(uint256(69));
@@ -71,7 +71,7 @@ abstract contract ManagedERC721 is IManagedERC721, Versioned, IERC6454, IERC6982
     if (address(registry) != address(0)) revert AlreadyInitiated();
     if (registry_ == address(0) || guardian_ == address(0) || managerProxy_ == address(0)) revert ZeroAddress();
     guardian = Guardian(guardian_);
-    registry = IERC6551Registry(registry_);
+    registry = ICrunaRegistry(registry_);
     managerProxy = Manager(managerProxy_);
   }
 
@@ -154,7 +154,7 @@ abstract contract ManagedERC721 is IManagedERC721, Versioned, IERC6454, IERC6982
     // the max supply is 999,999
     if (nextTokenId % 1e6 == 0) revert SupplyCapReached();
     if (address(registry) == address(0)) revert NotInitiated();
-    try registry.createAccount(address(managerProxy), SALT, block.chainid, address(this), nextTokenId) {} catch {
+    try registry.createBondContract(address(managerProxy), SALT, block.chainid, address(this), nextTokenId) {} catch {
       revert ErrorCreatingManager();
     }
     _safeMint(to, nextTokenId++);
@@ -163,6 +163,6 @@ abstract contract ManagedERC721 is IManagedERC721, Versioned, IERC6454, IERC6982
   // @dev This function will return the address of the manager for tokenId.
   // @param tokenId The id of the token.
   function managerOf(uint256 tokenId) public view returns (address) {
-    return registry.account(address(managerProxy), SALT, block.chainid, address(this), tokenId);
+    return registry.bondContract(address(managerProxy), SALT, block.chainid, address(this), tokenId);
   }
 }

--- a/contracts/utils/CrunaRegistry.sol
+++ b/contracts/utils/CrunaRegistry.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+// Modified registry based on CrunaRegistry
+// https://github.com/erc6551/reference/blob/main/src/CrunaRegistry.sol
+
+// We deploy our own registry to avoid misleading observers that may believe
+// that managers and plugins are accounts.
+
+// import "hardhat/console.sol";
+
+interface ICrunaRegistry {
+  /**
+   * @dev The registry MUST emit the ERC6551AccountCreated event upon successful account creation.
+   */
+  event BondContractCreated(
+    address contractAddress,
+    address indexed implementation,
+    bytes32 salt,
+    uint256 chainId,
+    address indexed tokenContract,
+    uint256 indexed tokenId
+  );
+
+  /**
+   * @dev The registry MUST revert with AccountCreationFailed error if the create2 operation fails.
+   */
+  error BondContractCreationFailed();
+
+  /**
+   * @dev Creates a token bound account for a non-fungible token.
+   *
+   * If account has already been created, returns the account address without calling create2.
+   *
+   * Emits ERC6551AccountCreated event.
+   *
+   * @return account The address of the token bound account
+   */
+  function createBondContract(
+    address implementation,
+    bytes32 salt,
+    uint256 chainId,
+    address tokenContract,
+    uint256 tokenId
+  ) external returns (address account);
+
+  /**
+   * @dev Returns the computed token bound account address for a non-fungible token.
+   *
+   * @return account The address of the token bound account
+   */
+  function bondContract(
+    address implementation,
+    bytes32 salt,
+    uint256 chainId,
+    address tokenContract,
+    uint256 tokenId
+  ) external view returns (address account);
+}
+
+contract CrunaRegistry is ICrunaRegistry {
+  function createBondContract(
+    address implementation,
+    bytes32 salt,
+    uint256 chainId,
+    address tokenContract,
+    uint256 tokenId
+  ) external returns (address) {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      // Memory Layout:
+      // ----
+      // 0x00   0xff                           (1 byte)
+      // 0x01   registry (address)             (20 bytes)
+      // 0x15   salt (bytes32)                 (32 bytes)
+      // 0x35   Bytecode Hash (bytes32)        (32 bytes)
+      // ----
+      // 0x55   ERC-1167 Constructor + Header  (20 bytes)
+      // 0x69   implementation (address)       (20 bytes)
+      // 0x5D   ERC-1167 Footer                (15 bytes)
+      // 0x8C   salt (uint256)                 (32 bytes)
+      // 0xAC   chainId (uint256)              (32 bytes)
+      // 0xCC   tokenContract (address)        (32 bytes)
+      // 0xEC   tokenId (uint256)              (32 bytes)
+
+      // Silence unused variable warnings
+      pop(chainId)
+
+      // Copy bytecode + constant data to memory
+      calldatacopy(0x8c, 0x24, 0x80) // salt, chainId, tokenContract, tokenId
+      mstore(0x6c, 0x5af43d82803e903d91602b57fd5bf3) // ERC-1167 footer
+      mstore(0x5d, implementation) // implementation
+      mstore(0x49, 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
+
+      // Copy create2 computation data to memory
+      mstore8(0x00, 0xff) // 0xFF
+      mstore(0x35, keccak256(0x55, 0xb7)) // keccak256(bytecode)
+      mstore(0x01, shl(96, address())) // registry address
+      mstore(0x15, salt) // salt
+
+      // Compute account address
+      let computed := keccak256(0x00, 0x55)
+
+      // If the account has not yet been deployed
+      if iszero(extcodesize(computed)) {
+        // Deploy account contract
+        let deployed := create2(0, 0x55, 0xb7, salt)
+
+        // Revert if the deployment fails
+        if iszero(deployed) {
+          mstore(0x00, 0xbe697d1a) // `BondContractCreationFailed()`
+          revert(0x1c, 0x04)
+        }
+
+        // Store account address in memory before salt and chainId
+        mstore(0x6c, deployed)
+
+        // Emit the BondContractCreated event
+        log4(
+          0x6c,
+          0x60,
+          0xff00099476635104b75fe596675c8480d3c7355eff23f5538c88a52844ad18f9,
+          implementation,
+          tokenContract,
+          tokenId
+        )
+
+        // Return the account address
+        return(0x6c, 0x20)
+      }
+
+      // Otherwise, return the computed account address
+      mstore(0x00, shr(96, shl(96, computed)))
+      return(0x00, 0x20)
+    }
+  }
+
+  function bondContract(
+    address implementation,
+    bytes32 salt,
+    uint256 chainId,
+    address tokenContract,
+    uint256 tokenId
+  ) external view returns (address) {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      // Silence unused variable warnings
+      pop(chainId)
+      pop(tokenContract)
+      pop(tokenId)
+
+      // Copy bytecode + constant data to memory
+      calldatacopy(0x8c, 0x24, 0x80) // salt, chainId, tokenContract, tokenId
+      mstore(0x6c, 0x5af43d82803e903d91602b57fd5bf3) // ERC-1167 footer
+      mstore(0x5d, implementation) // implementation
+      mstore(0x49, 0x3d60ad80600a3d3981f3363d3d373d3d3d363d73) // ERC-1167 constructor + header
+
+      // Copy create2 computation data to memory
+      mstore8(0x00, 0xff) // 0xFF
+      mstore(0x35, keccak256(0x55, 0xb7)) // keccak256(bytecode)
+      mstore(0x01, shl(96, address())) // registry address
+      mstore(0x15, salt) // salt
+
+      // Store computed account address in memory
+      mstore(0x00, shr(96, shl(96, keccak256(0x00, 0x55))))
+
+      // Return computed account address
+      return(0x00, 0x20)
+    }
+  }
+}

--- a/contracts/utils/CrunaRegistry.sol
+++ b/contracts/utils/CrunaRegistry.sol
@@ -13,7 +13,7 @@ interface ICrunaRegistry {
   /**
    * @dev The registry MUST emit the ERC6551AccountCreated event upon successful account creation.
    */
-  event BondContractCreated(
+  event BoundContractCreated(
     address contractAddress,
     address indexed implementation,
     bytes32 salt,
@@ -25,7 +25,7 @@ interface ICrunaRegistry {
   /**
    * @dev The registry MUST revert with AccountCreationFailed error if the create2 operation fails.
    */
-  error BondContractCreationFailed();
+  error BoundContractCreationFailed();
 
   /**
    * @dev Creates a token bound account for a non-fungible token.
@@ -36,7 +36,7 @@ interface ICrunaRegistry {
    *
    * @return account The address of the token bound account
    */
-  function createBondContract(
+  function createBoundContract(
     address implementation,
     bytes32 salt,
     uint256 chainId,
@@ -59,7 +59,7 @@ interface ICrunaRegistry {
 }
 
 contract CrunaRegistry is ICrunaRegistry {
-  function createBondContract(
+  function createBoundContract(
     address implementation,
     bytes32 salt,
     uint256 chainId,
@@ -108,18 +108,18 @@ contract CrunaRegistry is ICrunaRegistry {
 
         // Revert if the deployment fails
         if iszero(deployed) {
-          mstore(0x00, 0xbe697d1a) // `BondContractCreationFailed()`
+          mstore(0x00, 0xbe697d1a) // `BoundContractCreationFailed()`
           revert(0x1c, 0x04)
         }
 
         // Store account address in memory before salt and chainId
         mstore(0x6c, deployed)
 
-        // Emit the BondContractCreated event
+        // Emit the BoundContractCreated event
         log4(
           0x6c,
           0x60,
-          0xff00099476635104b75fe596675c8480d3c7355eff23f5538c88a52844ad18f9,
+          0x1f0e50ba751c22f20c414b4c1d531bced4cc983fe16d3a8ed9a167c0cdd674d3,
           implementation,
           tokenContract,
           tokenId

--- a/contracts/utils/SignatureValidator.sol
+++ b/contracts/utils/SignatureValidator.sol
@@ -8,7 +8,7 @@ import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
 // @dev This contract is used to validate signatures.
 //   It is based on EIP712 and supports typed messages V4.
-contract SignatureValidator is EIP712 {
+abstract contract SignatureValidator is EIP712 {
   using ECDSA for bytes32;
 
   error TimestampInvalidOrExpired();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cruna/protocol",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "The Cruna protocol",
   "publishConfig": {
     "access": "public"

--- a/scripts/deploy-all.js
+++ b/scripts/deploy-all.js
@@ -27,15 +27,15 @@ async function main() {
   await deployUtils.deployNickSFactory(deployer);
 
   let erc6551RegistryAddress = "0x000000006551c19487814612e58FE06813775758";
-  registry = await deployUtils.attach("ERC6551Registry", erc6551RegistryAddress);
+  registry = await deployUtils.attach("CrunaRegistry", erc6551RegistryAddress);
   try {
-    let salt = deployUtils.keccak256("ERC6551Registry");
+    let salt = deployUtils.keccak256("CrunaRegistry");
     let implementation = "0xdD2FD4581271e230360230F9337D5c0430Bf44C0";
     let tokenContract = "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199";
 
-    await registry.account(implementation, salt, chainId, tokenContract, 1);
+    await registry.bondContract(implementation, salt, chainId, tokenContract, 1);
   } catch (e) {
-    registry = await deployUtils.deploy("ERC6551Registry");
+    registry = await deployUtils.deploy("CrunaRegistry");
     erc6551RegistryAddress = registry.address;
   }
 

--- a/scripts/deploy-all.js
+++ b/scripts/deploy-all.js
@@ -26,8 +26,8 @@ async function main() {
 
   await deployUtils.deployNickSFactory(deployer);
 
-  let erc6551RegistryAddress = "0x000000006551c19487814612e58FE06813775758";
-  registry = await deployUtils.attach("CrunaRegistry", erc6551RegistryAddress);
+  let crunaRegistryAddress = "0x000000006551c19487814612e58FE06813775758";
+  registry = await deployUtils.attach("CrunaRegistry", crunaRegistryAddress);
   try {
     let salt = deployUtils.keccak256("CrunaRegistry");
     let implementation = "0xdD2FD4581271e230360230F9337D5c0430Bf44C0";
@@ -36,7 +36,7 @@ async function main() {
     await registry.bondContract(implementation, salt, chainId, tokenContract, 1);
   } catch (e) {
     registry = await deployUtils.deploy("CrunaRegistry");
-    erc6551RegistryAddress = registry.address;
+    crunaRegistryAddress = registry.address;
   }
 
   async function deployIfNotDeployed(
@@ -90,7 +90,7 @@ async function main() {
 
   vault = await deployUtils.attach("CrunaFlexiVault");
   await deployUtils.Tx(
-    vault.init(erc6551RegistryAddress, guardianAddress, signatureValidatorAddress, managerProxyAddress, { gasLimit: 120000 }),
+    vault.init(crunaRegistryAddress, guardianAddress, signatureValidatorAddress, managerProxyAddress, { gasLimit: 120000 }),
     "Init vault",
   );
 

--- a/scripts/deploy-fix.js
+++ b/scripts/deploy-fix.js
@@ -15,7 +15,7 @@ async function main() {
 
   const [deployer] = await ethers.getSigners();
 
-  let registry = await deployUtils.attach("ERC6551Registry");
+  let registry = await deployUtils.attach("CrunaRegistry");
   let guardian = await deployUtils.attach("Guardian");
   let managerProxy = await deployUtils.attach("ManagerProxy");
   let signatureValidator = await deployUtils.attach("SignatureValidator");

--- a/scripts/deploy-testnet.js
+++ b/scripts/deploy-testnet.js
@@ -15,7 +15,7 @@ async function main() {
 
   const [deployer] = await ethers.getSigners();
 
-  let registry = await deployUtils.attach("ERC6551Registry");
+  let registry = await deployUtils.attach("CrunaRegistry");
   let manager = await deployUtils.deploy("Manager");
   let guardian = await deployUtils.deploy("Guardian", deployer.address);
   let managerProxy = await deployUtils.deploy("ManagerProxy", manager.address);

--- a/scripts/exportABIs.js
+++ b/scripts/exportABIs.js
@@ -11,7 +11,7 @@ async function main() {
     let json = require(source);
     ABIs.contracts[rename || name] = json.abi;
   }
-  abi("ERC6551Registry", "erc6551");
+  abi("CrunaRegistry", "erc6551");
   abi("Manager", "contracts/manager");
   abi("FlexiProxy", "contracts/utils");
   abi("InheritancePlugin", "contracts/plugins/inheritance");

--- a/scripts/find-unused-custom-errors.js
+++ b/scripts/find-unused-custom-errors.js
@@ -13,9 +13,14 @@ function findUnusedCustomErrors(contractContent) {
   return errors.filter((error) => !RegExp("revert " + error + "\\(", "g").test(contractContent));
 }
 
+const skipFiles = ["CrunaRegistry.sol"];
+
 function analyzeContracts(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   entries.forEach((entry) => {
+    if (skipFiles.includes(entry.name)) {
+      return;
+    }
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       analyzeContracts(fullPath);

--- a/test/ContractsDevelopment.test.js
+++ b/test/ContractsDevelopment.test.js
@@ -30,7 +30,7 @@ describe("Testing contract deployments", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("ERC6551Registry");
+    erc6551Registry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     proxy = await deployContract("ManagerProxy", managerImpl.address);

--- a/test/ContractsDevelopment.test.js
+++ b/test/ContractsDevelopment.test.js
@@ -16,7 +16,7 @@ const {
 } = require("./helpers");
 
 describe("Testing contract deployments", function () {
-  let erc6551Registry, proxy, managerImpl, guardian;
+  let crunaRegistry, proxy, managerImpl, guardian;
   let vault;
   let factory;
   let usdc, usdt;
@@ -30,13 +30,13 @@ describe("Testing contract deployments", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("CrunaRegistry");
+    crunaRegistry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     proxy = await deployContract("ManagerProxy", managerImpl.address);
 
     vault = await deployContract("CrunaFlexiVault", deployer.address);
-    await vault.init(erc6551Registry.address, guardian.address, proxy.address);
+    await vault.init(crunaRegistry.address, guardian.address, proxy.address);
     factory = await deployContractUpgradeable("VaultFactory", [vault.address]);
 
     await vault.setFactory(factory.address);
@@ -66,7 +66,7 @@ describe("Testing contract deployments", function () {
     const nextTokenId = await vault.nextTokenId();
     const managerAddress = await vault.managerOf(nextTokenId);
     expect(await ethers.provider.getCode(managerAddress)).equal("0x");
-    await factory.connect(bob).buyVaults(usdc.address, 1);
+    await factory.connect(bob).buyVaults(usdc.address, 1, true);
     expect(await ethers.provider.getCode(managerAddress)).not.equal("0x");
     const manager = await ethers.getContractAt("Manager", managerAddress);
     expect(await manager.tokenId()).to.equal(nextTokenId);

--- a/test/InheritanceManager.Sentinels.test.js
+++ b/test/InheritanceManager.Sentinels.test.js
@@ -34,7 +34,7 @@ describe("Sentinel and Inheritance", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("ERC6551Registry");
+    erc6551Registry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     managerProxy = await deployContract("ManagerProxy", managerImpl.address);
@@ -65,18 +65,14 @@ describe("Sentinel and Inheritance", function () {
     const manager = await ethers.getContractAt("Manager", await vault.managerOf(nextTokenId));
     inheritancePluginImpl = await deployContract("InheritancePlugin");
     inheritancePluginProxy = await deployContract("InheritancePluginProxy", inheritancePluginImpl.address);
-    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginImpl.address, true)).to.be.revertedWith(
-      "NotAProxy",
-    );
+    await expect(manager.connect(bob).plug("InheritancePlugin", vault.address, true)).to.be.revertedWith("NotAProxy");
+
     await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address, true)).to.be.revertedWith(
       "InvalidImplementation",
     );
     const nameHash = bytes4(keccak256("InheritancePlugin"));
     await guardian.setTrustedImplementation(nameHash, inheritancePluginProxy.address, true);
     expect((await manager.pluginsByName(nameHash)).proxyAddress).to.equal(addr0);
-    await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address, false)).to.be.revertedWith(
-      "InconsistentPolicy",
-    );
 
     await expect(manager.connect(bob).plug("InheritancePlugin", inheritancePluginProxy.address, true)).to.emit(
       manager,

--- a/test/InheritanceManager.Sentinels.test.js
+++ b/test/InheritanceManager.Sentinels.test.js
@@ -17,7 +17,7 @@ const {
 } = require("./helpers");
 
 describe("Sentinel and Inheritance", function () {
-  let erc6551Registry, managerProxy, managerImpl, guardian;
+  let crunaRegistry, managerProxy, managerImpl, guardian;
   let vault, inheritancePluginProxy, inheritancePluginImpl;
   let factory;
   let usdc, usdt;
@@ -34,13 +34,13 @@ describe("Sentinel and Inheritance", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("CrunaRegistry");
+    crunaRegistry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     managerProxy = await deployContract("ManagerProxy", managerImpl.address);
 
     vault = await deployContract("CrunaFlexiVault", deployer.address);
-    await vault.init(erc6551Registry.address, guardian.address, managerProxy.address);
+    await vault.init(crunaRegistry.address, guardian.address, managerProxy.address);
     factory = await deployContractUpgradeable("VaultFactory", [vault.address]);
 
     await vault.setFactory(factory.address);
@@ -61,7 +61,7 @@ describe("Sentinel and Inheritance", function () {
     const price = await factory.finalPrice(usdc.address);
     await usdc.connect(bob).approve(factory.address, price);
     const nextTokenId = await vault.nextTokenId();
-    await factory.connect(bob).buyVaults(usdc.address, 1);
+    await factory.connect(bob).buyVaults(usdc.address, 1, true);
     const manager = await ethers.getContractAt("Manager", await vault.managerOf(nextTokenId));
     inheritancePluginImpl = await deployContract("InheritancePlugin");
     inheritancePluginProxy = await deployContract("InheritancePluginProxy", inheritancePluginImpl.address);

--- a/test/Manager.Protectors.test.js
+++ b/test/Manager.Protectors.test.js
@@ -15,6 +15,7 @@ const {
   keccak256,
   bytes4,
   combineBytes4ToBytes32,
+  getInterfaceId,
 } = require("./helpers");
 
 describe("Manager : Protectors", function () {
@@ -32,7 +33,7 @@ describe("Manager : Protectors", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("ERC6551Registry");
+    erc6551Registry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     proxy = await deployContract("ManagerProxy", managerImpl.address);
@@ -66,9 +67,10 @@ describe("Manager : Protectors", function () {
   it("should support the IManagedERC721.sol interface", async function () {
     const vaultMock = await deployContract("VaultMock", deployer.address);
     await vaultMock.init(erc6551Registry.address, guardian.address, proxy.address);
-    const interfaceId = await vaultMock.getIProtectedInterfaceId();
+    let interfaceId = await vaultMock.getIProtectedInterfaceId();
     expect(interfaceId).to.equal("0xe19a64da");
     expect(await vault.supportsInterface(interfaceId)).to.be.true;
+    expect(await getInterfaceId("IManagedERC721")).to.equal("0xe19a64da");
   });
 
   it("should verify ManagerBase parameters", async function () {
@@ -86,8 +88,8 @@ describe("Manager : Protectors", function () {
   it("should verify vault base parameters", async function () {
     expect(await vault.defaultLocked()).to.be.false;
     const tokenId = await buyAVault(bob);
-    expect(await vault.tokenURI(tokenId)).to.equal("https://meta.cruna.cc/flexy-vault/v1/3133701000001");
-    expect(await vault.contractURI()).to.equal("https://meta.cruna.cc/flexy-vault/v1/info");
+    expect(await vault.tokenURI(tokenId)).to.equal("https://meta.cruna.cc/flexi-vault/v1/3133701000001");
+    expect(await vault.contractURI()).to.equal("https://meta.cruna.cc/flexi-vault/v1/info");
     expect(await vault.locked(tokenId)).to.be.false;
     expect(await vault.isTransferable(tokenId, bob.address, addr0)).to.be.false;
     expect(await vault.isTransferable(tokenId, bob.address, bob.address)).to.be.false;

--- a/test/Manager.SafeRecipients.test.js
+++ b/test/Manager.SafeRecipients.test.js
@@ -16,7 +16,7 @@ const {
 } = require("./helpers");
 
 describe("Manager : Safe Recipients", function () {
-  let erc6551Registry, proxy, managerImpl, guardian;
+  let crunaRegistry, proxy, managerImpl, guardian;
   let vault;
   let factory;
   let usdc, usdt;
@@ -30,13 +30,13 @@ describe("Manager : Safe Recipients", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("CrunaRegistry");
+    crunaRegistry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     proxy = await deployContract("ManagerProxy", managerImpl.address);
 
     vault = await deployContract("CrunaFlexiVault", deployer.address);
-    await vault.init(erc6551Registry.address, guardian.address, proxy.address);
+    await vault.init(crunaRegistry.address, guardian.address, proxy.address);
     factory = await deployContractUpgradeable("VaultFactory", [vault.address]);
 
     await vault.setFactory(factory.address);
@@ -57,7 +57,7 @@ describe("Manager : Safe Recipients", function () {
     const price = await factory.finalPrice(usdc.address);
     await usdc.connect(bob).approve(factory.address, price);
     const nextTokenId = await vault.nextTokenId();
-    await factory.connect(bob).buyVaults(usdc.address, 1);
+    await factory.connect(bob).buyVaults(usdc.address, 1, true);
     return nextTokenId;
   };
 

--- a/test/Manager.SafeRecipients.test.js
+++ b/test/Manager.SafeRecipients.test.js
@@ -30,7 +30,7 @@ describe("Manager : Safe Recipients", function () {
   });
 
   beforeEach(async function () {
-    erc6551Registry = await deployContract("ERC6551Registry");
+    erc6551Registry = await deployContract("CrunaRegistry");
     managerImpl = await deployContract("Manager");
     guardian = await deployContract("Guardian", deployer.address);
     proxy = await deployContract("ManagerProxy", managerImpl.address);

--- a/test/SignatureValidator.test.js
+++ b/test/SignatureValidator.test.js
@@ -28,7 +28,7 @@ describe("SignatureValidator", function () {
   });
 
   beforeEach(async function () {
-    validator = await deployContract("SignatureValidator");
+    validator = await deployContract("ValidatorMock");
   });
 
   it("should recover the signer of a recoverSigner", async function () {

--- a/test/VaultFactory.test.js
+++ b/test/VaultFactory.test.js
@@ -14,6 +14,7 @@ const {
   keccak256,
   deployAll,
   upgradeProxy,
+  bytes4,
   deployContractViaNickSFactory,
 } = require("./helpers");
 
@@ -62,7 +63,7 @@ describe("VaultFactory", function () {
     await expect(factory.connect(bob).buyVaults(usdc.address, 1))
       .to.emit(vault, "Transfer")
       .withArgs(addr0, bob.address, nextTokenId)
-      .to.emit(erc6551Registry, "ERC6551AccountCreated")
+      .to.emit(erc6551Registry, "BondContractCreated")
       .withArgs(
         precalculatedAddress,
         toChecksumAddress(proxy.address),

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -139,12 +139,12 @@ const Helpers = {
 
     const erc6551RegistryAddress = await Helpers.deployContractViaNickSFactory(
       deployer,
-      "ERC6551Registry",
+      "CrunaRegistry",
       undefined,
       undefined,
       "0x0000000000000000000000000000000000000000fd8eb4e1dca713016c518e31",
     );
-    const erc6551Registry = await ethers.getContractAt("ERC6551Registry", erc6551RegistryAddress);
+    const erc6551Registry = await ethers.getContractAt("CrunaRegistry", erc6551RegistryAddress);
 
     const managerAddress = await Helpers.deployContractViaNickSFactory(deployer, "Manager");
     const manager = await ethers.getContractAt("Manager", managerAddress);
@@ -335,6 +335,18 @@ const Helpers = {
       ),
       message,
     ];
+  },
+
+  async getInterfaceId(interfaceName) {
+    const artifact = await hre.artifacts.readArtifact(interfaceName);
+    const abi = artifact.abi;
+    const functions = abi.filter((item) => item.type === "function");
+    let interfaceId = ethers.constants.Zero;
+    functions.forEach((func) => {
+      const selector = ethers.utils.id(func.name + "(" + func.inputs.map((input) => input.type).join(",") + ")").slice(0, 10);
+      interfaceId = interfaceId.xor(selector);
+    });
+    return interfaceId.toHexString();
   },
 };
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -137,14 +137,14 @@ const Helpers = {
     // using Nick's factory
     await Helpers.deployNickSFactory(deployer);
 
-    const erc6551RegistryAddress = await Helpers.deployContractViaNickSFactory(
+    const crunaRegistryAddress = await Helpers.deployContractViaNickSFactory(
       deployer,
       "CrunaRegistry",
       undefined,
       undefined,
       "0x0000000000000000000000000000000000000000fd8eb4e1dca713016c518e31",
     );
-    const erc6551Registry = await ethers.getContractAt("CrunaRegistry", erc6551RegistryAddress);
+    const crunaRegistry = await ethers.getContractAt("CrunaRegistry", crunaRegistryAddress);
 
     const managerAddress = await Helpers.deployContractViaNickSFactory(deployer, "Manager");
     const manager = await ethers.getContractAt("Manager", managerAddress);
@@ -162,9 +162,9 @@ const Helpers = {
       [deployer.address],
     );
     const vault = await ethers.getContractAt("CrunaFlexiVault", vaultAddress);
-    await vault.init(erc6551RegistryAddress, guardianAddress, proxyAddress);
+    await vault.init(crunaRegistryAddress, guardianAddress, proxyAddress);
 
-    return [erc6551Registry, proxy, guardian, vault];
+    return [crunaRegistry, proxy, guardian, vault];
   },
 
   async getAddressViaNickSFactory(deployer, contractName, constructorTypes, constructorArgs, salt = thiz.keccak256("Cruna")) {


### PR DESCRIPTION
In version 1.0.0-alpha.6 it allow the user to optionally mint a token without creating a manager for the token. It also adds a function `activate` to activate the token later.